### PR TITLE
feat: match app footer exactly to landing page with white theme

### DIFF
--- a/frontend/src/app/shared/components/footer/footer.component.css
+++ b/frontend/src/app/shared/components/footer/footer.component.css
@@ -1,105 +1,160 @@
+/* Main footer element */
 .footer {
   position: fixed;
   bottom: 0;
   left: 0;
   width: 100%;
   height: var(--footer-height);
-  background-color: #f5f5f5;
-  border-top: 1px solid #e0e0e0;
-  z-index: 50;
-  transition: height 0.3s ease;
+  backdrop-filter: blur(10px);
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
+  z-index: 999;
+  font-family: 'Afacad Flux', sans-serif;
 }
 
-.footer-content {
+/* Footer container wrapper */
+.footer-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 var(--spacing-xl);
   display: flex;
   justify-content: space-between;
   align-items: center;
   height: 100%;
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 var(--spacing-md);
+  gap: 1rem;
 }
 
-.footer-text {
-  font-family: "Afacad Flux", sans-serif;
-  font-weight: 400;
-  margin: 0;
-  color: #666;
-  font-size: 0.75rem;
-}
-
-.footer-links {
+/* Left side container */
+.footer-left {
+  flex: 1;
   display: flex;
-  gap: var(--spacing-md);
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
-.footer-links a {
+/* Copyright text */
+.footer-copyright {
+  color: rgba(0, 0, 0, 0.9);
+  font-size: 0.7rem;
+  font-weight: 500;
+  font-family: 'Afacad Flux', sans-serif;
+  margin: 0;
+  line-height: 1.2;
+}
+
+/* Disclaimer text */
+.footer-disclaimer {
+  color: rgba(0, 0, 0, 0.6);
+  font-size: 0.7rem;
+  font-weight: 400;
+  font-family: 'Afacad Flux', sans-serif;
+  line-height: 1.3;
+  margin: 0;
+  max-width: 600px;
+}
+
+/* Social icons container */
+.footer-social {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+/* Social icon links */
+.footer-social a {
   display: flex;
   align-items: center;
-  gap: 4px;
-  font-size: 0.75rem;
-  color: var(--text-color);
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  color: rgba(0, 0, 0, 0.7);
   text-decoration: none;
-  transition: color 0.2s;
+  position: relative;
+  overflow: hidden;
+  transition: all 0.3s ease;
 }
 
-.footer-links a:hover {
-  color: var(--primary-color);
+/* Hover background effect */
+.footer-social a::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: var(--primary-color);
+  border-radius: 50%;
+  transform: scale(0);
+  transition: transform 0.3s ease;
+  z-index: -1;
 }
 
-.footer-icon {
-  font-size: 18px;
-  height: 18px;
-  width: 18px;
+/* Hover state */
+.footer-social a:hover::before {
+  transform: scale(1);
+}
+
+.footer-social a:hover {
+  color: white;
+  transform: translateY(-2px);
+}
+
+/* Mobile Responsive Styles */
+@media (max-width: 768px) {
+  .footer-container {
+    gap: 0.75rem;
+    padding: 0 var(--spacing-md);
+  }
+
+  .footer-copyright {
+    display: none;
+  }
+
+  .footer-disclaimer {
+    font-size: 0.65rem;
+    max-width: 360px;
+  }
+
+  .footer-social {
+    gap: 0.75rem;
+  }
+
+  .footer-social a {
+    width: 36px;
+    height: 36px;
+  }
 }
 
 @media (max-width: 599px) {
-  .footer-content {
-    padding: 0;
-    justify-content: center;
-    align-items: center;
+  .footer-disclaimer {
+    font-size: 0.6rem;
+    max-width: 320px;
+  }
+}
+
+@media (max-width: 480px) {
+  .footer-disclaimer {
+    display: none;
   }
 
   .footer-text {
     display: none;
   }
 
-  .footer-links {
+  .footer-container {
+    justify-content: center;
+  }
+
+  .footer-left {
+    display: none;
+  }
+
+  .footer-social {
     display: flex;
     justify-content: center;
     align-items: center;
     gap: var(--spacing-xl);
     width: 100%;
-  }
-
-  .footer-links a {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    padding: var(--spacing-sm);
-  }
-
-  .footer-links a span {
-    display: none;
-  }
-}
-
-/* For iOS safe areas */
-@supports (padding: max(0px)) {
-  .footer {
-    padding-bottom: env(safe-area-inset-bottom);
-    height: calc(var(--footer-height) + env(safe-area-inset-bottom));
-  }
-
-  .footer-content {
-    padding-left: max(var(--spacing-md), env(safe-area-inset-left));
-    padding-right: max(var(--spacing-md), env(safe-area-inset-right));
-  }
-
-  @media (max-width: 599px) {
-    .footer-content {
-      padding-left: env(safe-area-inset-left);
-      padding-right: env(safe-area-inset-right);
-    }
   }
 }

--- a/frontend/src/app/shared/components/footer/footer.component.html
+++ b/frontend/src/app/shared/components/footer/footer.component.html
@@ -1,26 +1,77 @@
-<footer class="footer">
-  <div class="footer-content">
-    <p class="footer-text">
-      © {{ currentYear }} Quasar Secure Chat. All rights reserved.
-    </p>
-    <div class="footer-links">
+<footer class="footer" role="contentinfo">
+  <div class="footer-container">
+    <div class="footer-left">
+      <div class="footer-copyright">© {{ currentYear }} Quasar Development</div>
+      <div class="footer-disclaimer">
+        No warranty provided. Distributed 'as is' under GPL-3.0. Author not
+        responsible for usage or security implications.
+      </div>
+    </div>
+    <div class="footer-social">
+      <a
+        href="https://github.com/art2url/quasar-contact-app"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Source code of project"
+      >
+        <!-- Source Code Icon -->
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 512 512"
+          fill="currentColor"
+          aria-hidden="true"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <g clip-path="url(#clip0_553_1881)">
+            <path
+              d="M256 0C397.385 0 512 114.615 512 256C512 397.385 397.385 512 256 512C114.615 512 0 397.385 0 256C0 114.615 114.615 0 256 0ZM312.066 174.143L393.557 255.633L312.066 337.122L340.351 365.407L450.125 255.633L340.351 145.858L312.066 174.143ZM60.7148 255.632L170.489 365.406L198.773 337.122L117.283 255.632L198.773 174.143L170.489 145.857L60.7148 255.632ZM204.565 347.914H245.5L302.83 162.568L262.5 162.567L204.565 347.914Z"
+            />
+          </g>
+          <defs>
+            <clipPath id="clip0_553_1881">
+              <rect width="512" height="512" fill="white" />
+            </clipPath>
+          </defs>
+        </svg>
+      </a>
       <a
         href="https://github.com/art2url"
         target="_blank"
         rel="noopener noreferrer"
-        aria-label="GitHub"
+        aria-label="Author of the Project"
       >
-        <mat-icon class="footer-icon">code</mat-icon>
-        <span>GitHub</span>
+        <!-- GitHub Icon -->
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"
+          />
+        </svg>
       </a>
       <a
         href="https://www.linkedin.com/in/artem-turlenko"
         target="_blank"
         rel="noopener noreferrer"
-        aria-label="LinkedIn"
+        aria-label="Connect with Author of the Project on LinkedIn"
       >
-        <mat-icon class="footer-icon">business_center</mat-icon>
-        <span>LinkedIn</span>
+        <!-- LinkedIn Icon -->
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"
+          />
+        </svg>
       </a>
     </div>
   </div>

--- a/frontend/src/app/shared/components/footer/footer.component.ts
+++ b/frontend/src/app/shared/components/footer/footer.component.ts
@@ -1,11 +1,10 @@
-import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { MatIconModule } from '@angular/material/icon';
+import {Component} from '@angular/core';
+import {CommonModule} from '@angular/common';
 
 @Component({
   selector: 'app-footer',
   standalone: true,
-  imports: [CommonModule, MatIconModule],
+  imports: [CommonModule],
   templateUrl: './footer.component.html',
   styleUrl: './footer.component.css',
 })

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,5 +1,5 @@
 /* You can add global styles to this file, and also import other style files */
-@import "@angular/material/prebuilt-themes/indigo-pink.css";
+@import '@angular/material/prebuilt-themes/indigo-pink.css';
 
 /* Global Angular Material button hover override */
 .header button:hover,
@@ -53,7 +53,7 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: "Raleway", sans-serif !important;
+  font-family: 'Raleway', sans-serif !important;
   font-optical-sizing: auto;
   font-weight: 700;
   font-style: normal;
@@ -62,59 +62,59 @@ h6 {
 /* 2. Base elements use Afacad Flux */
 html,
 body {
-  font-family: "Afacad Flux", sans-serif;
+  font-family: 'Afacad Flux', sans-serif;
   font-optical-sizing: auto;
 }
 
 /* 3. All other elements use Afacad Flux, but exclude icons AND headers */
-*:not(.material-icons):not(.mat-icon):not([class*="icon"]):not(
+*:not(.material-icons):not(.mat-icon):not([class*='icon']):not(
     [data-mat-icon-type]
   ):not(.mdi):not(.fa):not(.fas):not(.far):not(.fab):not(.fal):not(.fad):not(
     .fass
   ):not(.fasr):not(.fasl):not(.fasd):not(h1):not(h2):not(h3):not(h4):not(
     h5
   ):not(h6) {
-  font-family: "Afacad Flux", sans-serif !important;
+  font-family: 'Afacad Flux', sans-serif !important;
   font-optical-sizing: auto;
 }
 
 /* 4. Specific HTML elements (excluding icons) */
 p,
 span:not(.material-icons):not(.mat-icon),
-div:not([class*="icon"]),
+div:not([class*='icon']),
 button:not(.mat-icon-button) span:not(.material-icons),
 input,
-input[type="text"],
-input[type="email"],
-input[type="password"],
-input[type="file"],
-input[type="search"],
-input[type="tel"],
-input[type="url"],
-input[type="number"],
+input[type='text'],
+input[type='email'],
+input[type='password'],
+input[type='file'],
+input[type='search'],
+input[type='tel'],
+input[type='url'],
+input[type='number'],
 textarea,
 select,
-label:not([class*="icon"]),
-a:not([class*="icon"]),
+label:not([class*='icon']),
+a:not([class*='icon']),
 li,
 td,
 th,
 caption {
-  font-family: "Afacad Flux", sans-serif !important;
+  font-family: 'Afacad Flux', sans-serif !important;
   font-optical-sizing: auto;
 }
 
 /* Additional specific override for all inputs */
 input:not(.material-icons):not(.mat-icon) {
-  font-family: "Afacad Flux", sans-serif !important;
+  font-family: 'Afacad Flux', sans-serif !important;
   font-optical-sizing: auto;
 }
 
 /* Override Angular generated input styles */
-input[class*="_ngcontent"],
+input[class*='_ngcontent'],
 input[_ngcontent],
 input[ng-reflect] {
-  font-family: "Afacad Flux", sans-serif !important;
+  font-family: 'Afacad Flux', sans-serif !important;
   font-optical-sizing: auto;
 }
 
@@ -144,7 +144,7 @@ input[ng-reflect] {
 .mat-dialog-content,
 .mat-snack-bar-container,
 .mat-tooltip {
-  font-family: "Afacad Flux", sans-serif !important;
+  font-family: 'Afacad Flux', sans-serif !important;
 }
 
 /* 6. Override Material Design Components (MDC) typography (excluding icons) */
@@ -180,7 +180,7 @@ input[ng-reflect] {
 .mat-mdc-dialog-content,
 .mat-mdc-snack-bar-container,
 .mat-mdc-tooltip {
-  font-family: "Afacad Flux", sans-serif !important;
+  font-family: 'Afacad Flux', sans-serif !important;
 }
 
 /* 7. Preserve icon fonts - explicitly keep their original font families */
@@ -197,8 +197,8 @@ input[ng-reflect] {
 .fasr,
 .fasl,
 .fasd,
-[class*="icon-"]:before,
-[class*="icon-"]:after,
+[class*='icon-']:before,
+[class*='icon-']:after,
 .mat-icon-button .mat-icon,
 .mat-form-field-suffix .mat-icon,
 .mat-form-field-prefix .mat-icon,
@@ -206,39 +206,39 @@ input[ng-reflect] {
 .mat-datepicker-toggle-default-icon,
 .mat-calendar-arrow,
 .mat-expansion-indicator::after {
-  font-family: "Material Icons", "Material Icons Outlined",
-    "Font Awesome 5 Free", "Font Awesome 5 Pro", "MDI" !important;
+  font-family: 'Material Icons', 'Material Icons Outlined',
+    'Font Awesome 5 Free', 'Font Awesome 5 Pro', 'MDI' !important;
 }
 
 /* 8. Override CSS custom properties for non-header typography */
 :root {
-  --mat-sys-typescale-display-large-font-family-name: "Afacad Flux", sans-serif;
-  --mat-sys-typescale-display-medium-font-family-name: "Afacad Flux", sans-serif;
-  --mat-sys-typescale-display-small-font-family-name: "Afacad Flux", sans-serif;
-  --mat-sys-typescale-headline-large-font-family-name: "Raleway", sans-serif;
-  --mat-sys-typescale-headline-medium-font-family-name: "Raleway", sans-serif;
-  --mat-sys-typescale-headline-small-font-family-name: "Raleway", sans-serif;
-  --mat-sys-typescale-title-large-font-family-name: "Raleway", sans-serif;
-  --mat-sys-typescale-title-medium-font-family-name: "Raleway", sans-serif;
-  --mat-sys-typescale-title-small-font-family-name: "Raleway", sans-serif;
-  --mat-sys-typescale-label-large-font-family-name: "Afacad Flux", sans-serif;
-  --mat-sys-typescale-label-medium-font-family-name: "Afacad Flux", sans-serif;
-  --mat-sys-typescale-label-small-font-family-name: "Afacad Flux", sans-serif;
-  --mat-sys-typescale-body-large-font-family-name: "Afacad Flux", sans-serif;
-  --mat-sys-typescale-body-medium-font-family-name: "Afacad Flux", sans-serif;
-  --mat-sys-typescale-body-small-font-family-name: "Afacad Flux", sans-serif;
+  --mat-sys-typescale-display-large-font-family-name: 'Afacad Flux', sans-serif;
+  --mat-sys-typescale-display-medium-font-family-name: 'Afacad Flux', sans-serif;
+  --mat-sys-typescale-display-small-font-family-name: 'Afacad Flux', sans-serif;
+  --mat-sys-typescale-headline-large-font-family-name: 'Raleway', sans-serif;
+  --mat-sys-typescale-headline-medium-font-family-name: 'Raleway', sans-serif;
+  --mat-sys-typescale-headline-small-font-family-name: 'Raleway', sans-serif;
+  --mat-sys-typescale-title-large-font-family-name: 'Raleway', sans-serif;
+  --mat-sys-typescale-title-medium-font-family-name: 'Raleway', sans-serif;
+  --mat-sys-typescale-title-small-font-family-name: 'Raleway', sans-serif;
+  --mat-sys-typescale-label-large-font-family-name: 'Afacad Flux', sans-serif;
+  --mat-sys-typescale-label-medium-font-family-name: 'Afacad Flux', sans-serif;
+  --mat-sys-typescale-label-small-font-family-name: 'Afacad Flux', sans-serif;
+  --mat-sys-typescale-body-large-font-family-name: 'Afacad Flux', sans-serif;
+  --mat-sys-typescale-body-medium-font-family-name: 'Afacad Flux', sans-serif;
+  --mat-sys-typescale-body-small-font-family-name: 'Afacad Flux', sans-serif;
 }
 
 /* 9. Ensure Material Icons stay intact */
 .mat-icon {
-  font-family: "Material Icons" !important;
-  font-feature-settings: "liga";
+  font-family: 'Material Icons' !important;
+  font-feature-settings: 'liga';
 }
 
 .material-icons {
-  font-family: "Material Icons" !important;
-  font-feature-settings: "liga";
-  -webkit-font-feature-settings: "liga";
+  font-family: 'Material Icons' !important;
+  font-feature-settings: 'liga';
+  -webkit-font-feature-settings: 'liga';
   -webkit-font-smoothing: antialiased;
 }
 
@@ -255,14 +255,12 @@ input[ng-reflect] {
   --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.12);
   --border-radius: 8px;
   --header-height: 64px;
-  --footer-height: 60px;
+  --footer-height: 80px;
   --spacing-xs: 4px;
   --spacing-sm: 8px;
   --spacing-md: 16px;
   --spacing-lg: 24px;
   --spacing-xl: 32px;
-  --header-height: 64px;
-  --footer-height: 60px;
 }
 
 html,
@@ -289,7 +287,7 @@ body {
 @media (max-width: 599px) {
   :root {
     --header-height: 56px;
-    --footer-height: 52px;
+    --footer-height: 60px;
   }
 
   .mobile-hidden {
@@ -330,7 +328,7 @@ body {
   width: 100%;
   max-width: 1200px;
   margin: 0 auto;
-  padding: 0 var(--spacing-md);
+  padding: 0 var(--spacing-xl);
   box-sizing: border-box;
 }
 

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -213,7 +213,7 @@ body::before {
 }
 
 .logo-image:hover {
-  transform: scale(1.1) rotate(5deg);
+  transform: scale(1.1) rotate(0);
 }
 
 .header .logo-text {
@@ -821,7 +821,7 @@ h1 {
   }
 
   .footer-left {
-    align-items: center;
+    align-items: left;
     gap: 0.5rem;
   }
 


### PR DESCRIPTION
- Use exact same 3 icons (source code, GitHub, LinkedIn) from landing page
- Add same copyright text and GPL disclaimer
- Implement identical layout structure and responsive behavior
- Apply white color palette
- Remove Material Icons dependency for footer component