### PR TITLE
feat: implement consistent 1200px container layout across components

### DIFF
--- a/frontend/src/app/features/chat/chat-list/chat-list.component.css
+++ b/frontend/src/app/features/chat/chat-list/chat-list.component.css
@@ -1,12 +1,15 @@
 .chat-container {
   max-width: 1200px;
+  width: 100%;
   margin: 0 auto;
+  padding: 0 var(--spacing-xl);
+  box-sizing: border-box;
 }
 
 .chat-header {
   display: flex;
   align-items: center;
-  margin-bottom: var(--spacing-lg);
+  margin-bottom: var(--spacing-md);
   padding: var(--spacing-md) 0;
   border-bottom: 1px solid var(--border-color);
 }
@@ -208,18 +211,41 @@
   background-color: white !important;
 }
 
-@media (max-width: 599px) {
+@media (max-width: 768px) {
   .chat-container {
-    padding: var(--spacing-sm);
+    padding: 0 var(--spacing-md);
+  }
+}
+
+@media (max-width: 599px) {
+  .chat-header {
+    margin-bottom: var(--spacing-md);
+    padding: var(--spacing-sm) 0;
+  }
+
+  .chat-top {
+    margin-bottom: 0;
+  }
+
+  .chat-header h2 {
+    font-size: larger;
+    margin: 0;
+    color: var(--text-color);
+  }
+
+  .chat-name {
+    font-size: small;
+    margin-bottom: 0;
   }
 
   .chat-list a {
-    padding: var(--spacing-sm);
+    padding: var(--spacing-xs) var(--spacing-md);
   }
 
   .avatar {
-    width: 40px;
-    height: 40px;
+    width: 36px;
+    height: 36px;
+    margin-right: 12px;
   }
 
   .last-message {
@@ -229,22 +255,5 @@
   .search-result-btn,
   .chat-list a {
     min-height: 60px;
-  }
-}
-
-/* For iOS safe areas */
-@supports (padding: max(0px)) {
-  .chat-container {
-    padding-left: max(var(--spacing-md), env(safe-area-inset-left));
-    padding-right: max(var(--spacing-md), env(safe-area-inset-right));
-    padding-bottom: max(var(--spacing-md), env(safe-area-inset-bottom));
-  }
-
-  @media (max-width: 599px) {
-    .chat-container {
-      padding-left: max(var(--spacing-sm), env(safe-area-inset-left));
-      padding-right: max(var(--spacing-sm), env(safe-area-inset-right));
-      padding-bottom: max(var(--spacing-sm), env(safe-area-inset-bottom));
-    }
   }
 }

--- a/frontend/src/app/features/chat/chat-room/chat-room.component.css
+++ b/frontend/src/app/features/chat/chat-room/chat-room.component.css
@@ -1,28 +1,49 @@
+.chat-wrapper {
+  max-width: 1200px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 0 var(--spacing-xl);
+  box-sizing: border-box;
+}
+
 .chat-container {
   display: flex;
   flex-direction: column;
   height: calc(100vh - var(--header-height) - var(--footer-height) - 32px);
-  max-width: 1200px;
-  margin: 0 auto;
+  width: 100%;
   border-radius: var(--border-radius);
   background-color: white;
   box-shadow: var(--shadow-sm);
   overflow: hidden;
-  /* Add z-index to ensure chat container is above other elements */
   z-index: 1;
+  box-sizing: border-box;
 }
 
 .chat-header {
   display: flex;
   align-items: center;
-  padding: var(--spacing-md);
+  padding: var(--spacing-md) 0;
   border-bottom: 1px solid var(--border-color);
   background-color: #f8f9fa;
+  justify-content: space-between;
+}
+
+/* Left side: back button + user info */
+.left-side {
+  display: flex;
+  align-items: center;
+  flex: 1;
+}
+
+/* Right side: status */
+.right-side {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
 }
 
 .back-button {
   margin-right: var(--spacing-sm);
-  /* Always visible on mobile */
   display: flex;
   align-items: center;
   justify-content: center;
@@ -47,6 +68,12 @@
   display: flex;
   align-items: center;
   flex: 1;
+  margin: 0;
+}
+
+.user-info h3 {
+  font-size: larger;
+  margin: 0;
 }
 
 .avatar {
@@ -68,13 +95,14 @@
   color: #666;
   display: flex;
   align-items: center;
+  gap: 0.25rem;
+  padding-right: 1rem;
 }
 
 .status-dot {
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  margin-right: 4px;
 }
 
 .status-dot.online {
@@ -91,10 +119,9 @@
   padding: var(--spacing-md);
   display: flex;
   flex-direction: column;
-  -webkit-overflow-scrolling: touch; /* Add for better scrolling on iOS */
-  position: relative; /* For positioning scroll button */
-  scroll-behavior: smooth; /* Add smooth scrolling */
-  /* Add padding bottom to prevent typing indicator from being hidden */
+  -webkit-overflow-scrolling: touch;
+  position: relative;
+  scroll-behavior: smooth;
   padding-bottom: calc(var(--spacing-md) + 40px);
 }
 
@@ -123,7 +150,7 @@
 }
 
 .date-header::before {
-  content: "";
+  content: '';
   position: absolute;
   left: 0;
   right: 0;
@@ -152,7 +179,8 @@
 
 .message {
   font-weight: 400;
-  font-family: "Open Sans", sans-serif;
+  /* TODO */
+  font-family: 'Open Sans', sans-serif;
   font-size: 1rem;
   padding: var(--spacing-sm) var(--spacing-md);
   border-radius: 18px;
@@ -215,7 +243,7 @@
   background-color: white;
   border-radius: 12px;
   box-shadow: var(--shadow-sm);
-  z-index: 2; /* Ensure actions are above other elements */
+  z-index: 2;
 }
 
 .message:hover .message-actions {
@@ -229,7 +257,7 @@
   padding: 4px 8px;
   cursor: pointer;
   color: #666;
-  min-height: 44px; /* Larger touch target for mobile */
+  min-height: 44px;
   min-width: 44px;
   display: flex;
   align-items: center;
@@ -264,7 +292,7 @@
 
 /* Add typing animation dots */
 .typing-indicator::after {
-  content: "";
+  content: '';
   display: inline-block;
   width: 20px;
   text-align: left;
@@ -274,30 +302,19 @@
 @keyframes typingDots {
   0%,
   20% {
-    content: "";
+    content: '';
   }
   40% {
-    content: ".";
+    content: '.';
   }
   60% {
-    content: "..";
+    content: '..';
   }
   80%,
   100% {
-    content: "...";
+    content: '...';
   }
 }
-
-/* @keyframes fadeInUp {
-  from {
-    opacity: 0;
-    transform: translateY(10px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-} */
 
 /* Scroll to bottom button repositioned to center-bottom */
 .scroll-to-bottom-btn {
@@ -374,7 +391,7 @@
   border-top: 1px solid var(--border-color);
   background-color: white;
   position: relative;
-  z-index: 3; /* Ensure form is above typing indicator */
+  z-index: 3;
 }
 
 .message-input {
@@ -386,7 +403,7 @@
   resize: none;
   max-height: 100px;
   overflow-y: auto;
-  font-size: 16px; /* Prevents iOS zoom */
+  font-size: 16px;
   transition: opacity 0.2s ease;
 }
 
@@ -431,7 +448,7 @@
   border: none;
   cursor: pointer;
   margin-left: 8px;
-  min-height: 44px; /* Larger touch target for mobile */
+  min-height: 44px;
   min-width: 44px;
 }
 
@@ -463,8 +480,6 @@
 .key-missing {
   color: var(--warning-color);
 }
-
-/* Add these styles to chat-room.component.css */
 
 /* Styling for unreadable messages */
 .message.unreadable {
@@ -531,12 +546,35 @@
   display: flex;
 }
 
+@media (max-width: 768px) {
+  .chat-wrapper {
+    padding: 0 var(--spacing-md);
+  }
+}
+
 /* Mobile adjustments */
 @media (max-width: 599px) {
+  /* .chat-wrapper {
+    padding: 0 var(--spacing-sm);
+  } */
+
   .chat-container {
     height: calc(100vh - var(--header-height) - var(--footer-height) - 16px);
     border-radius: 0;
     box-shadow: none;
+    margin-bottom: var(--spacing-xs);
+  }
+
+  .chat-header {
+    padding: var(--spacing-sm) 0;
+  }
+
+  .avatar {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    margin-right: var(--spacing-sm);
+    object-fit: cover;
   }
 
   .chat-window {
@@ -546,6 +584,17 @@
 
   .back-button {
     display: flex; /* Always show back button on mobile */
+  }
+
+  .settings-header h3 {
+    font-size: small;
+    margin: 0;
+    color: var(--text-color);
+  }
+
+  .avatar {
+    width: 30px;
+    height: 30px;
   }
 
   .message {
@@ -625,30 +674,5 @@
 
   .messages-loading p {
     font-size: 0.8rem;
-  }
-}
-
-/* For iOS safe areas */
-@supports (padding: max(0px)) {
-  .chat-container {
-    height: calc(
-      100vh - var(--header-height) - var(--footer-height) - 32px -
-        env(safe-area-inset-top) - env(safe-area-inset-bottom)
-    );
-  }
-
-  .scroll-to-bottom-btn {
-    bottom: calc(var(--footer-height) + 20px + env(safe-area-inset-bottom));
-    left: 50%; /* Keep centered */
-    transform: translateX(-50%); /* Perfect centering */
-  }
-
-  @media (max-width: 599px) {
-    .chat-container {
-      height: calc(
-        100vh - var(--header-height) - var(--footer-height) - 16px -
-          env(safe-area-inset-top) - env(safe-area-inset-bottom)
-      );
-    }
   }
 }

--- a/frontend/src/app/features/chat/chat-room/chat-room.component.html
+++ b/frontend/src/app/features/chat/chat-room/chat-room.component.html
@@ -1,234 +1,245 @@
-<div class="chat-container">
-  <div class="chat-header">
-    <!-- Always show back button for mobile, not just with *ngIf -->
-    <button
-      mat-icon-button
-      class="back-button"
-      (click)="navigateToList($event)"
-    >
-      <mat-icon>arrow_back</mat-icon>
-    </button>
+<div class="chat-wrapper">
+  <div class="chat-container">
+    <div class="chat-header">
+      <div class="left-side">
+        <button
+          mat-icon-button
+          class="back-button"
+          (click)="navigateToList($event)"
+        >
+          <mat-icon>arrow_back</mat-icon>
+        </button>
 
-    <div class="user-info">
-      <img
-        [src]="getPartnerAvatar()"
-        [alt]="(chat.theirUsername$ | async) || 'User'"
-        class="avatar"
-      />
-      <div>
-        <h3 class="username">{{ (chat.theirUsername$ | async) || "User" }}</h3>
+        <div class="user-info">
+          <img
+            [src]="getPartnerAvatar()"
+            [alt]="(chat.theirUsername$ | async) || 'User'"
+            class="avatar"
+          />
+          <div>
+            <h3 class="username">
+              {{ (chat.theirUsername$ | async) || 'User' }}
+            </h3>
+          </div>
+        </div>
+      </div>
+
+      <!-- Right side: status -->
+      <div class="right-side">
         <div class="status">
           <span
             class="status-dot"
             [class.online]="isPartnerOnline"
             [class.offline]="!isPartnerOnline"
           ></span>
-          <span>{{ isPartnerOnline ? "Online" : "Offline" }}</span>
+          <span>{{ isPartnerOnline ? 'Online' : 'Offline' }}</span>
         </div>
       </div>
     </div>
-  </div>
 
-  <app-cache-info-banner
-    [showBanner]="showCacheInfoBanner"
-  ></app-cache-info-banner>
+    <app-cache-info-banner
+      [showBanner]="showCacheInfoBanner"
+    ></app-cache-info-banner>
 
-  <!-- Public key status -->
-  <ng-container *ngIf="chat.keyLoading$ | async as loading">
-    <div *ngIf="loading" class="key-loading">Loading user's public key...</div>
-    <div
-      *ngIf="!loading && (chat.keyMissing$ | async) === true"
-      class="key-missing"
-    >
-      User hasn't uploaded a public key. Messages will be sent unencrypted.
-    </div>
-  </ng-container>
-
-  <!-- Chat window -->
-  <div #messageContainer class="chat-window">
-    <!-- Loading state for messages -->
-    <div *ngIf="isLoadingMessages" class="messages-loading">
+    <!-- Public key status -->
+    <ng-container *ngIf="chat.keyLoading$ | async as loading">
+      <div *ngIf="loading" class="key-loading">
+        Loading user's public key...
+      </div>
       <div
-        style="
-          display: flex;
-          flex-direction: column;
-          align-items: center;
-          justify-content: center;
-          padding: 40px;
-        "
+        *ngIf="!loading && (chat.keyMissing$ | async) === true"
+        class="key-missing"
       >
-        <mat-spinner diameter="40" color="primary"></mat-spinner>
-        <p style="margin-top: 16px; color: #666">Loading messages...</p>
+        User hasn't uploaded a public key. Messages will be sent unencrypted.
       </div>
-    </div>
-
-    <!-- Only show messages when loading is complete -->
-    <ng-container *ngIf="!isLoadingMessages">
-      <!-- Empty state -->
-      <div *ngIf="!messageGroups.length" class="empty-chat">
-        <mat-icon>chat</mat-icon>
-        <p>No messages yet</p>
-        <p>Start the conversation by sending a message</p>
-      </div>
-
-      <!-- Grouped messages with date headers -->
-      <ng-container *ngFor="let group of messageGroups; trackBy: trackByDate">
-        <!-- Date header -->
-        <div class="date-header">
-          <span class="date-text">{{ group.date }}</span>
-        </div>
-
-        <!-- Messages in this date group -->
-        <div
-          *ngFor="let m of group.messages; trackBy: trackByTs"
-          class="message"
-          [class.you]="m.sender === 'You'"
-          [class.other]="m.sender !== 'You'"
-          [class.deleted]="m.deletedAt"
-          [class.unreadable]="isMessageUnreadable(m)"
-        >
-          <div class="message-bubble">
-            <p class="message-content">{{ m.text }}</p>
-
-            <div class="message-meta">
-              <span class="message-time" [title]="getFullTimestamp(m.ts)">
-                {{ formatMessageTime(m.ts) }}
-              </span>
-
-              <span *ngIf="m.sender === 'You'" class="message-status">
-                <ng-container [ngSwitch]="m.status">
-                  <mat-icon *ngSwitchCase="'pending'" class="status-icon"
-                    >schedule</mat-icon
-                  >
-                  <mat-icon *ngSwitchCase="'sent'" class="status-icon"
-                    >check</mat-icon
-                  >
-                  <mat-icon *ngSwitchCase="'read'" class="status-icon"
-                    >done_all</mat-icon
-                  >
-                </ng-container>
-              </span>
-
-              <small *ngIf="!m.deletedAt && m.editedAt">&nbsp;(edited)</small>
-
-              <!-- Show indicator for unreadable messages -->
-              <small
-                *ngIf="isMessageUnreadable(m)"
-                class="unreadable-indicator"
-              >
-                &nbsp;(text unavailable)
-              </small>
-            </div>
-
-            <!--  Action buttons only for editable messages -->
-            <div *ngIf="canEditMessage(m)" class="message-actions">
-              <button
-                class="action-btn"
-                (click)="beginEdit(m)"
-                title="Edit"
-                [disabled]="!canEditMessage(m)"
-              >
-                <mat-icon>edit</mat-icon>
-              </button>
-              <button
-                class="action-btn"
-                (click)="delete(m)"
-                title="Delete"
-                [disabled]="!canEditMessage(m)"
-              >
-                <mat-icon>delete</mat-icon>
-              </button>
-            </div>
-
-            <!-- Show info for unreadable messages -->
-            <div
-              *ngIf="isMessageUnreadable(m)"
-              class="message-actions unreadable-actions"
-            >
-              <small class="unreadable-info">
-                <mat-icon class="info-icon">lock</mat-icon>
-                Cannot edit/delete
-              </small>
-            </div>
-          </div>
-        </div>
-      </ng-container>
     </ng-container>
 
-    <!-- Scroll to bottom button with new message badge (only show when not loading) -->
-    <button
-      *ngIf="showScrollToBottomButton && !isLoadingMessages"
-      class="scroll-to-bottom-btn"
-      (click)="scrollToBottomClick()"
-      [title]="
-        newMessagesCount > 0
-          ? newMessagesCount + ' new messages'
-          : 'Scroll to bottom'
-      "
-    >
-      <mat-icon>keyboard_arrow_down</mat-icon>
-      <span *ngIf="newMessagesCount > 0" class="message-badge">{{
-        newMessagesCount
-      }}</span>
-    </button>
+    <!-- Chat window -->
+    <div #messageContainer class="chat-window">
+      <!-- Loading state for messages -->
+      <div *ngIf="isLoadingMessages" class="messages-loading">
+        <div
+          style="
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            padding: 40px;
+          "
+        >
+          <mat-spinner diameter="40" color="primary"></mat-spinner>
+          <p style="margin-top: 16px; color: #666">Loading messages...</p>
+        </div>
+      </div>
+
+      <!-- Only show messages when loading is complete -->
+      <ng-container *ngIf="!isLoadingMessages">
+        <!-- Empty state -->
+        <div *ngIf="!messageGroups.length" class="empty-chat">
+          <mat-icon>chat</mat-icon>
+          <p>No messages yet</p>
+          <p>Start the conversation by sending a message</p>
+        </div>
+
+        <!-- Grouped messages with date headers -->
+        <ng-container *ngFor="let group of messageGroups; trackBy: trackByDate">
+          <!-- Date header -->
+          <div class="date-header">
+            <span class="date-text">{{ group.date }}</span>
+          </div>
+
+          <!-- Messages in this date group -->
+          <div
+            *ngFor="let m of group.messages; trackBy: trackByTs"
+            class="message"
+            [class.you]="m.sender === 'You'"
+            [class.other]="m.sender !== 'You'"
+            [class.deleted]="m.deletedAt"
+            [class.unreadable]="isMessageUnreadable(m)"
+          >
+            <div class="message-bubble">
+              <p class="message-content">{{ m.text }}</p>
+
+              <div class="message-meta">
+                <span class="message-time" [title]="getFullTimestamp(m.ts)">
+                  {{ formatMessageTime(m.ts) }}
+                </span>
+
+                <span *ngIf="m.sender === 'You'" class="message-status">
+                  <ng-container [ngSwitch]="m.status">
+                    <mat-icon *ngSwitchCase="'pending'" class="status-icon"
+                      >schedule</mat-icon
+                    >
+                    <mat-icon *ngSwitchCase="'sent'" class="status-icon"
+                      >check</mat-icon
+                    >
+                    <mat-icon *ngSwitchCase="'read'" class="status-icon"
+                      >done_all</mat-icon
+                    >
+                  </ng-container>
+                </span>
+
+                <small *ngIf="!m.deletedAt && m.editedAt">&nbsp;(edited)</small>
+
+                <!-- Show indicator for unreadable messages -->
+                <small
+                  *ngIf="isMessageUnreadable(m)"
+                  class="unreadable-indicator"
+                >
+                  &nbsp;(text unavailable)
+                </small>
+              </div>
+
+              <!--  Action buttons only for editable messages -->
+              <div *ngIf="canEditMessage(m)" class="message-actions">
+                <button
+                  class="action-btn"
+                  (click)="beginEdit(m)"
+                  title="Edit"
+                  [disabled]="!canEditMessage(m)"
+                >
+                  <mat-icon>edit</mat-icon>
+                </button>
+                <button
+                  class="action-btn"
+                  (click)="delete(m)"
+                  title="Delete"
+                  [disabled]="!canEditMessage(m)"
+                >
+                  <mat-icon>delete</mat-icon>
+                </button>
+              </div>
+
+              <!-- Show info for unreadable messages -->
+              <div
+                *ngIf="isMessageUnreadable(m)"
+                class="message-actions unreadable-actions"
+              >
+                <small class="unreadable-info">
+                  <mat-icon class="info-icon">lock</mat-icon>
+                  Cannot edit/delete
+                </small>
+              </div>
+            </div>
+          </div>
+        </ng-container>
+      </ng-container>
+
+      <!-- Scroll to bottom button with new message badge (only show when not loading) -->
+      <button
+        *ngIf="showScrollToBottomButton && !isLoadingMessages"
+        class="scroll-to-bottom-btn"
+        (click)="scrollToBottomClick()"
+        [title]="
+          newMessagesCount > 0
+            ? newMessagesCount + ' new messages'
+            : 'Scroll to bottom'
+        "
+      >
+        <mat-icon>keyboard_arrow_down</mat-icon>
+        <span *ngIf="newMessagesCount > 0" class="message-badge">{{
+          newMessagesCount
+        }}</span>
+      </button>
+    </div>
+
+    <!-- Typing indicator positioned above message form -->
+    <div *ngIf="isPartnerTyping && !isLoadingMessages" class="typing-indicator">
+      {{ (chat.theirUsername$ | async) || 'Partner' }} is typing
+    </div>
+
+    <!-- Message form -->
+    <form class="chat-form" (ngSubmit)="editing ? confirmEdit() : send()">
+      <textarea
+        *ngIf="!editing"
+        class="message-input"
+        [(ngModel)]="newMessage"
+        name="message"
+        placeholder="Type a message..."
+        required
+        (input)="onType()"
+        [rows]="1"
+        #messageInput
+        (keydown.enter)="onKeydownEnter($event)"
+        (keydown.enter.control)="onKeydownCtrlEnter($event)"
+        (keydown.enter.meta)="onKeydownMetaEnter($event)"
+        [disabled]="isLoadingMessages"
+      ></textarea>
+
+      <textarea
+        *ngIf="editing"
+        class="message-input"
+        [(ngModel)]="editDraft"
+        name="editDraft"
+        placeholder="Edit message..."
+        required
+        [rows]="1"
+        #editInput
+        (keydown.enter)="onKeydownEnterEdit($event)"
+        (keydown.enter.control)="onKeydownCtrlEnterEdit($event)"
+        (keydown.enter.meta)="onKeydownMetaEnterEdit($event)"
+      ></textarea>
+
+      <button
+        type="submit"
+        class="send-button"
+        [disabled]="
+          !(editing ? editDraft.trim() : newMessage.trim()) ||
+          (chat.connected$ | async) === false ||
+          isLoadingMessages
+        "
+      >
+        <mat-icon>{{ editing ? 'check' : 'send' }}</mat-icon>
+      </button>
+
+      <button
+        *ngIf="editing"
+        type="button"
+        class="cancel-button"
+        (click)="cancelEdit()"
+      >
+        <mat-icon>close</mat-icon>
+      </button>
+    </form>
   </div>
-
-  <!-- Typing indicator positioned above message form -->
-  <div *ngIf="isPartnerTyping && !isLoadingMessages" class="typing-indicator">
-    {{ (chat.theirUsername$ | async) || "Partner" }} is typing
-  </div>
-
-  <!-- Message form -->
-  <form class="chat-form" (ngSubmit)="editing ? confirmEdit() : send()">
-    <textarea
-      *ngIf="!editing"
-      class="message-input"
-      [(ngModel)]="newMessage"
-      name="message"
-      placeholder="Type a message..."
-      required
-      (input)="onType()"
-      [rows]="1"
-      #messageInput
-      (keydown.enter)="onKeydownEnter($event)"
-      (keydown.enter.control)="onKeydownCtrlEnter($event)"
-      (keydown.enter.meta)="onKeydownMetaEnter($event)"
-      [disabled]="isLoadingMessages"
-    ></textarea>
-
-    <textarea
-      *ngIf="editing"
-      class="message-input"
-      [(ngModel)]="editDraft"
-      name="editDraft"
-      placeholder="Edit message..."
-      required
-      [rows]="1"
-      #editInput
-      (keydown.enter)="onKeydownEnterEdit($event)"
-      (keydown.enter.control)="onKeydownCtrlEnterEdit($event)"
-      (keydown.enter.meta)="onKeydownMetaEnterEdit($event)"
-    ></textarea>
-
-    <button
-      type="submit"
-      class="send-button"
-      [disabled]="
-        !(editing ? editDraft.trim() : newMessage.trim()) ||
-        (chat.connected$ | async) === false ||
-        isLoadingMessages
-      "
-    >
-      <mat-icon>{{ editing ? "check" : "send" }}</mat-icon>
-    </button>
-
-    <button
-      *ngIf="editing"
-      type="button"
-      class="cancel-button"
-      (click)="cancelEdit()"
-    >
-      <mat-icon>close</mat-icon>
-    </button>
-  </form>
 </div>

--- a/frontend/src/app/features/settings/settings.component.css
+++ b/frontend/src/app/features/settings/settings.component.css
@@ -1,12 +1,15 @@
 .settings-container {
   max-width: 1200px;
+  width: 100%;
   margin: 0 auto;
+  padding: 0 var(--spacing-xl);
+  box-sizing: border-box;
 }
 
 .settings-header {
   display: flex;
   align-items: center;
-  margin-bottom: var(--spacing-lg);
+  margin-bottom: var(--spacing-md);
   padding: var(--spacing-md) 0;
   border-bottom: 1px solid var(--border-color);
 }
@@ -67,7 +70,7 @@
   padding: var(--spacing-sm) var(--spacing-md);
   border: none;
   border-radius: var(--border-radius);
-  font-family: "Afacad Flux", sans-serif !important;
+  font-family: 'Afacad Flux', sans-serif !important;
   font-optical-sizing: auto;
   font-size: 0.9rem;
   font-weight: 500;
@@ -122,7 +125,7 @@
 }
 
 .file-name {
-  font-family: "Afacad Flux", sans-serif !important;
+  font-family: 'Afacad Flux', sans-serif !important;
   font-optical-sizing: auto;
   font-size: 0.9rem;
   color: var(--text-color);
@@ -182,20 +185,37 @@
   margin-top: var(--spacing-sm);
   font-size: 0.8rem;
   color: #666;
-  font-family: "Afacad Flux", sans-serif !important;
+  font-family: 'Afacad Flux', sans-serif !important;
 }
 
 .error {
   color: var(--danger-color);
   font-size: 0.9rem;
   margin-top: var(--spacing-sm);
-  font-family: "Afacad Flux", sans-serif !important;
+  font-family: 'Afacad Flux', sans-serif !important;
+}
+
+@media (max-width: 768px) {
+  .settings-container {
+    padding: 0 var(--spacing-md);
+  }
 }
 
 @media (max-width: 599px) {
-  .settings-container {
-    padding: var(--spacing-sm);
+  .settings-header {
+    margin-bottom: var(--spacing-md);
+    padding: var(--spacing-sm) 0;
   }
+
+  .settings-header h2 {
+    font-size: larger;
+    margin: 0;
+    color: var(--text-color);
+  }
+
+  /* .settings-container {
+    padding: var(--spacing-sm);
+  } */
 
   .avatar-grid {
     grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
@@ -209,22 +229,5 @@
   .custom-action-button {
     width: 100%;
     justify-content: center;
-  }
-}
-
-/* For iOS safe areas */
-@supports (padding: max(0px)) {
-  .settings-container {
-    padding-left: max(var(--spacing-md), env(safe-area-inset-left));
-    padding-right: max(var(--spacing-md), env(safe-area-inset-right));
-    padding-bottom: max(var(--spacing-md), env(safe-area-inset-bottom));
-  }
-
-  @media (max-width: 599px) {
-    .settings-container {
-      padding-left: max(var(--spacing-sm), env(safe-area-inset-left));
-      padding-right: max(var(--spacing-sm), env(safe-area-inset-right));
-      padding-bottom: max(var(--spacing-sm), env(safe-area-inset-bottom));
-    }
   }
 }

--- a/frontend/src/app/shared/components/footer/footer.component.css
+++ b/frontend/src/app/shared/components/footer/footer.component.css
@@ -21,6 +21,7 @@
   align-items: center;
   height: 100%;
   gap: 1rem;
+  box-sizing: border-box;
 }
 
 /* Left side container */

--- a/frontend/src/app/shared/components/header/header.component.css
+++ b/frontend/src/app/shared/components/header/header.component.css
@@ -39,6 +39,7 @@
   padding: 0 var(--spacing-xl);
   max-width: 1200px;
   margin: 0 auto;
+  box-sizing: border-box;
 }
 
 .logo {


### PR DESCRIPTION
- Add proper padding and box-sizing to footer and header containers
- Update chat-room and chat-list components to follow same 1200px constraint
- Fix chat header layout with left-side (back button + user info) and right-side (status)
- Ensure all containers include padding within 1200px total width
- Add responsive padding adjustments for tablets (--spacing-md) and mobile (--spacing-sm)
- Remove iOS safe area support to prevent problems with view

Components updated:
- footer.component.css: Added container width constraint with padding
- header.component.css: Added container width constraint with padding
- chat-room.component.css: Updated container + fixed header layout structure
- chat-list.component.css: Updated container width constraint
- settings component: Applied same container pattern

This ensures consistent layout behavior where total width = 1200px including padding, content area = 1136px (1200px - 32px - 32px), matching landing page approach.