### PR TITLE
Fix/mobile chat UI improvements

### DIFF
--- a/frontend/src/app/features/chat/chat-room/chat-room.component.css
+++ b/frontend/src/app/features/chat/chat-room/chat-room.component.css
@@ -95,7 +95,7 @@
   color: #666;
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 8px;
   padding-right: 1rem;
 }
 
@@ -179,8 +179,6 @@
 
 .message {
   font-weight: 400;
-  /* TODO */
-  font-family: 'Open Sans', sans-serif;
   font-size: 1rem;
   padding: var(--spacing-sm) var(--spacing-md);
   border-radius: 18px;
@@ -576,25 +574,39 @@
   }
 
   .chat-container {
-    height: calc(
-      100vh - var(--header-height)
-    ); /* Use full height minus header since footer is hidden */
+    height: 100vh; /* Use full viewport height */
     border-radius: 0;
     box-shadow: none;
     margin: 0;
     position: relative;
+    display: flex;
+    flex-direction: column;
   }
 
   .chat-header {
-    padding: var(--spacing-sm) var(--spacing-md);
+    padding: 2px var(--spacing-md);
     /* Add horizontal padding back to header content */
+    position: fixed !important;
+    top: var(--header-height); /* Position directly below main app header */
+    left: 0;
+    right: 0;
+    background-color: #f8f9fa;
+    border-bottom: 1px solid var(--border-color);
+    z-index: 90; /* Below main header (100) but above chat content */
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    height: 60px; /* Fixed height for chat header */
+    display: flex;
+    align-items: center;
   }
 
   .chat-window {
     padding: var(--spacing-sm) var(--spacing-md);
     /* Add horizontal padding back to chat content */
+    padding-top: 70px; /* Reserve space for fixed chat header (60px + 10px margin) */
     padding-bottom: 90px; /* Reserve space for fixed input form */
-    height: calc(100% - 60px); /* Subtract header height */
+    height: 100vh;
+    overflow-y: auto;
+    margin-top: var(--header-height); /* Push down by main header height */
   }
 
   .chat-form {

--- a/frontend/src/app/features/chat/chat-room/chat-room.component.css
+++ b/frontend/src/app/features/chat/chat-room/chat-room.component.css
@@ -569,19 +569,47 @@
 
 /* Mobile adjustments */
 @media (max-width: 599px) {
-  /* .chat-wrapper {
-    padding: 0 var(--spacing-sm);
-  } */
+  /* Remove all padding for full-width chat */
+  .chat-wrapper {
+    padding: 0;
+    margin: 0;
+  }
 
   .chat-container {
-    height: calc(100vh - var(--header-height) - var(--footer-height) - 16px);
+    height: calc(
+      100vh - var(--header-height)
+    ); /* Use full height minus header since footer is hidden */
     border-radius: 0;
     box-shadow: none;
-    margin-bottom: var(--spacing-xs);
+    margin: 0;
+    position: relative;
   }
 
   .chat-header {
-    padding: var(--spacing-sm) 0;
+    padding: var(--spacing-sm) var(--spacing-md);
+    /* Add horizontal padding back to header content */
+  }
+
+  .chat-window {
+    padding: var(--spacing-sm) var(--spacing-md);
+    /* Add horizontal padding back to chat content */
+    padding-bottom: 90px; /* Reserve space for fixed input form */
+    height: calc(100% - 60px); /* Subtract header height */
+  }
+
+  .chat-form {
+    padding: var(--spacing-sm) var(--spacing-md);
+    /* Add horizontal padding back to form */
+    position: fixed !important;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: white;
+    border-top: 1px solid var(--border-color);
+    z-index: 1000;
+    /* Add safe area for mobile browsers */
+    padding-bottom: calc(var(--spacing-sm) + env(safe-area-inset-bottom));
+    box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.1);
   }
 
   .avatar {
@@ -590,11 +618,6 @@
     border-radius: 50%;
     margin-right: var(--spacing-sm);
     object-fit: cover;
-  }
-
-  .chat-window {
-    /* Adjust padding for mobile to accommodate typing indicator */
-    padding-bottom: calc(var(--spacing-sm) + 50px);
   }
 
   .back-button {
@@ -614,10 +637,6 @@
 
   .message {
     max-width: 85%;
-  }
-
-  .chat-form {
-    padding: var(--spacing-sm);
   }
 
   /* Mobile typing indicator adjustments */
@@ -641,15 +660,21 @@
     min-width: 44px;
   }
 
-  /* Adjust scroll button position for mobile - center bottom */
+  /* Adjust scroll button position for mobile - remove flickering with transform3d */
   .scroll-to-bottom-btn {
-    bottom: calc(
-      var(--footer-height) + 16px + 70px
-    ); /* Closer to bottom on mobile */
-    left: 50%; /* Keep centered */
-    transform: translateX(-50%); /* Perfect centering */
+    position: fixed;
+    bottom: 100px; /* Fixed position above input */
+    left: 50%;
+    transform: translate3d(
+      -50%,
+      0,
+      0
+    ); /* Use transform3d for hardware acceleration */
     width: 44px;
     height: 44px;
+    /* Remove transitions that cause flickering */
+    transition: opacity 0.2s ease;
+    will-change: opacity; /* Optimize for opacity changes only */
   }
 
   .scroll-to-bottom-btn mat-icon {
@@ -691,5 +716,10 @@
 
   .messages-loading p {
     font-size: 0.8rem;
+  }
+
+  /* Prevent zoom on input focus for iOS */
+  .message-input {
+    font-size: 16px; /* Prevents zoom on iOS */
   }
 }

--- a/frontend/src/app/features/chat/chat-room/chat-room.component.html
+++ b/frontend/src/app/features/chat/chat-room/chat-room.component.html
@@ -165,30 +165,33 @@
         </ng-container>
       </ng-container>
 
-      <!-- Scroll to bottom button with new message badge (only show when not loading) -->
-      <button
-        *ngIf="showScrollToBottomButton && !isLoadingMessages"
-        class="scroll-to-bottom-btn"
-        (click)="scrollToBottomClick()"
-        [title]="
-          newMessagesCount > 0
-            ? newMessagesCount + ' new messages'
-            : 'Scroll to bottom'
-        "
+      <!-- Typing indicator positioned above message form -->
+      <div
+        *ngIf="isPartnerTyping && !isLoadingMessages"
+        class="typing-indicator"
       >
-        <mat-icon>keyboard_arrow_down</mat-icon>
-        <span *ngIf="newMessagesCount > 0" class="message-badge">{{
-          newMessagesCount
-        }}</span>
-      </button>
+        {{ (chat.theirUsername$ | async) || 'Partner' }} is typing
+      </div>
     </div>
 
-    <!-- Typing indicator positioned above message form -->
-    <div *ngIf="isPartnerTyping && !isLoadingMessages" class="typing-indicator">
-      {{ (chat.theirUsername$ | async) || 'Partner' }} is typing
-    </div>
+    <!-- Scroll to bottom button with new message badge (only show when not loading) -->
+    <button
+      *ngIf="showScrollToBottomButton && !isLoadingMessages"
+      class="scroll-to-bottom-btn"
+      (click)="scrollToBottomClick()"
+      [title]="
+        newMessagesCount > 0
+          ? newMessagesCount + ' new messages'
+          : 'Scroll to bottom'
+      "
+    >
+      <mat-icon>keyboard_arrow_down</mat-icon>
+      <span *ngIf="newMessagesCount > 0" class="message-badge">{{
+        newMessagesCount
+      }}</span>
+    </button>
 
-    <!-- Message form -->
+    <!-- Message form - keep inside container for desktop, fixed for mobile -->
     <form class="chat-form" (ngSubmit)="editing ? confirmEdit() : send()">
       <textarea
         *ngIf="!editing"

--- a/frontend/src/app/features/chat/chat-room/chat-room.component.ts
+++ b/frontend/src/app/features/chat/chat-room/chat-room.component.ts
@@ -156,6 +156,8 @@ export class ChatRoomComponent
   }
 
   async ngOnInit(): Promise<void> {
+    document.body.classList.add('chat-room-page');
+
     console.log('[ChatRoom] Component initializing');
     this.receiverId = this.route.snapshot.paramMap.get('id')!;
     console.log('[ChatRoom] Chat room ID:', this.receiverId);
@@ -1069,6 +1071,8 @@ export class ChatRoomComponent
   }
 
   ngOnDestroy() {
+    document.body.classList.remove('chat-room-page');
+
     console.log('[ChatRoom] Component destroying, cleaning up resources');
 
     // Remove event listeners from input element

--- a/frontend/src/app/shared/components/footer/footer.component.css
+++ b/frontend/src/app/shared/components/footer/footer.component.css
@@ -128,6 +128,11 @@
 }
 
 @media (max-width: 599px) {
+  /* Hide footer only when chat-room-page class is on body */
+  :host-context(.chat-room-page) .footer {
+    display: none;
+  }
+
   .footer-disclaimer {
     font-size: 0.6rem;
     max-width: 320px;
@@ -135,6 +140,11 @@
 }
 
 @media (max-width: 480px) {
+  /* Hide footer only when chat-room-page class is on body */
+  :host-context(.chat-room-page) .footer {
+    display: none;
+  }
+
   .footer-disclaimer {
     display: none;
   }

--- a/frontend/src/app/shared/components/header/header.component.css
+++ b/frontend/src/app/shared/components/header/header.component.css
@@ -94,7 +94,7 @@
 .status {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 8px;
   padding: 2px 6px;
   border-radius: 12px;
   font-size: 0.75rem;


### PR DESCRIPTION
* Remove scroll-to-bottom button flickering on mobile devices
* Implement full-width chat layout for screens ≤599px without padding/margins
* Fix input field disappearing on mobile browsers with fixed positioning
* Add safe area inset support for iOS devices
* Position chat form as fixed bottom element on mobile
* Hide footer only on chat room page for mobile screens ≤599px
* Add body class management for conditional footer display
* Make chat header always visible on mobile screens ≤599px
* Position chat header fixed below main app header
* Add proper z-index layering for UI elements
* Ensure back button and user info always accessible during scrolling
* Improve mobile UX by preventing navigation elements from disappearing