### PR TITLE
feat: integrate Privateemail email service

### DIFF
--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -5,6 +5,7 @@ dotenv.config();
 
 interface EnvConfig {
   PORT: number;
+  NODE_ENV: string;
   MONGO_URI: string;
   APP_NAME: string;
   JWT_SECRET: string;
@@ -25,6 +26,7 @@ interface EnvConfig {
 // Define and validate environment variables
 export const env: EnvConfig = {
   PORT: parseInt(process.env.PORT || '5000', 10),
+  NODE_ENV: process.env.NODE_ENV || 'development',
   MONGO_URI: process.env.MONGO_URI || '',
   APP_NAME: process.env.APP_NAME || 'Quasar Contact',
   JWT_SECRET: process.env.JWT_SECRET || '',
@@ -41,9 +43,7 @@ export const env: EnvConfig = {
   SMTP_SECURE: process.env.SMTP_SECURE === 'true',
   SMTP_USER: process.env.SMTP_USER,
   SMTP_PASS: process.env.SMTP_PASS,
-  SMTP_FROM:
-    process.env.SMTP_FROM ||
-    `noreply@${process.env.APP_NAME?.toLowerCase().replace(/\s+/g, '-')}.com`,
+  SMTP_FROM: process.env.SMTP_FROM || `noreply@quasar.contact`,
 };
 
 // Validate required environment variables
@@ -65,10 +65,22 @@ const validateEnv = () => {
   // Warn if email settings are not configured
   if (!env.SMTP_HOST || !env.SMTP_USER || !env.SMTP_PASS) {
     console.warn(
-      'WARNING: Email settings not configured. Password reset emails will not be sent.'
+      'WARNING: email settings not configured. Password reset emails will not be sent.'
     );
     console.warn(
       'To enable email functionality, set SMTP_HOST, SMTP_PORT, SMTP_USER, and SMTP_PASS in your .env file.'
+    );
+    console.warn(
+      'Example settings:\n' +
+        '  SMTP_HOST=mail.yourdomain.com\n' +
+        '  SMTP_PORT=587\n' +
+        '  SMTP_SECURE=false\n' +
+        '  SMTP_USER=noreply@yourdomain.com\n' +
+        '  SMTP_PASS=your-email-password'
+    );
+  } else {
+    console.log(
+      `[EmailService] email configured: ${env.SMTP_USER}@${env.SMTP_HOST}:${env.SMTP_PORT}`
     );
   }
 

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -1,15 +1,15 @@
 // Note: All encryption/decryption for chat messages is performed on the frontend using crypto.subtle.
 // The backend handles only user authentication (via JWT) and data storage.
 
-import {Router, type Request, type Response} from 'express';
-import {body, validationResult} from 'express-validator';
+import { Router, type Request, type Response } from 'express';
+import { body, validationResult } from 'express-validator';
 import jwt from 'jsonwebtoken';
 import bcrypt from 'bcryptjs';
 import crypto from 'crypto';
 import User from '../models/User';
 import Message from '../models/Message';
 import PasswordReset from '../models/PasswordReset';
-import {authLimiter} from '../config/ratelimits';
+import { authLimiter } from '../config/ratelimits';
 import env from '../config/env';
 import emailService from '../services/email.service';
 
@@ -20,33 +20,33 @@ router.post(
   '/register',
   [
     body('username')
-      .isLength({min: 3})
+      .isLength({ min: 3 })
       .withMessage('Username must be at least 3 characters long.'),
     // Require a valid email address.
     body('email').isEmail().withMessage('A valid email is required.'),
     body('password')
-      .isLength({min: 6})
+      .isLength({ min: 6 })
       .withMessage('Password must be at least 6 characters long.'),
   ],
   authLimiter,
   async (req: Request, res: Response) => {
     const errors = validationResult(req);
     if (!errors.isEmpty()) {
-      return res.status(422).json({errors: errors.array()});
+      return res.status(422).json({ errors: errors.array() });
     }
 
     // Destructure email along with username and password.
-    const {username, email, password, avatarUrl} = req.body;
+    const { username, email, password, avatarUrl } = req.body;
 
     try {
       // Optionally check if username or email already exists.
       const existingUser = await User.findOne({
-        $or: [{username}, {email}],
+        $or: [{ username }, { email }],
       });
       if (existingUser) {
         return res
           .status(409)
-          .json({message: 'Username or email already taken.'});
+          .json({ message: 'Username or email already taken.' });
       }
 
       // Hash password
@@ -62,10 +62,10 @@ router.post(
       });
       await newUser.save();
 
-      res.status(201).json({message: 'User registered successfully.'});
+      res.status(201).json({ message: 'User registered successfully.' });
     } catch (error) {
       console.error('[Register Error]', error);
-      res.status(500).json({message: 'Server error during registration.'});
+      res.status(500).json({ message: 'Server error during registration.' });
     }
   }
 );
@@ -81,20 +81,20 @@ router.post(
   async (req: Request, res: Response) => {
     const errors = validationResult(req);
     if (!errors.isEmpty()) {
-      return res.status(422).json({errors: errors.array()});
+      return res.status(422).json({ errors: errors.array() });
     }
 
-    const {username, password} = req.body;
+    const { username, password } = req.body;
 
     try {
       // Search for a user by either username or email.
       const user = await User.findOne({
-        $or: [{username: username}, {email: username}],
+        $or: [{ username: username }, { email: username }],
       });
       if (!user) {
         // Consider removing these console.logs in production
         console.log('User not found for:', username);
-        return res.status(401).json({message: 'Invalid credentials.'});
+        return res.status(401).json({ message: 'Invalid credentials.' });
       }
 
       // Consider removing these console.logs in production - they expose sensitive info
@@ -104,13 +104,17 @@ router.post(
       const isMatch = await bcrypt.compare(password, user.passwordHash);
       if (!isMatch) {
         console.log('Password mismatch for user:', username);
-        return res.status(401).json({message: 'Invalid credentials.'});
+        return res.status(401).json({ message: 'Invalid credentials.' });
       }
 
       const token = jwt.sign(
-        {userId: user._id, username: user.username, avatarUrl: user.avatarUrl},
+        {
+          userId: user._id,
+          username: user.username,
+          avatarUrl: user.avatarUrl,
+        },
         env.JWT_SECRET,
-        {expiresIn: '7d'}
+        { expiresIn: '7d' }
       );
 
       res.status(200).json({
@@ -124,7 +128,7 @@ router.post(
       });
     } catch (error) {
       console.error('[Login Error]', error);
-      res.status(500).json({message: 'Server error during login.'});
+      res.status(500).json({ message: 'Server error during login.' });
     }
   }
 );
@@ -137,14 +141,14 @@ router.post(
   async (req: Request, res: Response) => {
     const errors = validationResult(req);
     if (!errors.isEmpty()) {
-      return res.status(422).json({errors: errors.array()});
+      return res.status(422).json({ errors: errors.array() });
     }
 
-    const {email} = req.body;
+    const { email } = req.body;
 
     try {
       // Find user by email
-      const user = await User.findOne({email});
+      const user = await User.findOne({ email });
 
       // Always return success to prevent email enumeration
       if (!user) {
@@ -158,7 +162,7 @@ router.post(
       // Check if there's a recent reset request (rate limiting)
       const recentReset = await PasswordReset.findOne({
         userId: user._id,
-        createdAt: {$gte: new Date(Date.now() - 5 * 60 * 1000)}, // 5 minutes
+        createdAt: { $gte: new Date(Date.now() - 5 * 60 * 1000) }, // 5 minutes
         used: false,
       });
 
@@ -188,11 +192,8 @@ router.post(
         expiresAt: new Date(Date.now() + 60 * 60 * 1000), // 1 hour
       });
 
-      // Generate reset URL
-      const resetUrl = `${env.CLIENT_ORIGIN}/auth/reset-password?token=${resetToken}`;
-
-      // Send email
-      await emailService.sendPasswordResetEmail(user.email, resetUrl);
+      // Send email with just the token (email service will build the URL)
+      await emailService.sendPasswordResetEmail(user.email, resetToken);
 
       console.log('[Forgot Password] Reset email sent to:', email);
 
@@ -204,17 +205,17 @@ router.post(
       console.error('[Forgot Password Error]', error);
       res
         .status(500)
-        .json({message: 'Server error during password reset request.'});
+        .json({ message: 'Server error during password reset request.' });
     }
   }
 );
 
 // GET /api/auth/reset-password/validate
 router.get('/reset-password/validate', async (req: Request, res: Response) => {
-  const {token} = req.query;
+  const { token } = req.query;
 
   if (!token || typeof token !== 'string') {
-    return res.status(400).json({valid: false, message: 'Invalid token.'});
+    return res.status(400).json({ valid: false, message: 'Invalid token.' });
   }
 
   try {
@@ -224,20 +225,20 @@ router.get('/reset-password/validate', async (req: Request, res: Response) => {
     // Find valid reset record
     const resetRecord = await PasswordReset.findOne({
       token: hashedToken,
-      expiresAt: {$gt: new Date()},
+      expiresAt: { $gt: new Date() },
       used: false,
     });
 
     if (!resetRecord) {
       return res
         .status(400)
-        .json({valid: false, message: 'Invalid or expired token.'});
+        .json({ valid: false, message: 'Invalid or expired token.' });
     }
 
-    res.status(200).json({valid: true});
+    res.status(200).json({ valid: true });
   } catch (error) {
     console.error('[Validate Reset Token Error]', error);
-    res.status(500).json({valid: false, message: 'Server error.'});
+    res.status(500).json({ valid: false, message: 'Server error.' });
   }
 });
 
@@ -247,16 +248,16 @@ router.post(
   [
     body('token').notEmpty().withMessage('Reset token is required.'),
     body('password')
-      .isLength({min: 6})
+      .isLength({ min: 6 })
       .withMessage('Password must be at least 6 characters long.'),
   ],
   async (req: Request, res: Response) => {
     const errors = validationResult(req);
     if (!errors.isEmpty()) {
-      return res.status(422).json({errors: errors.array()});
+      return res.status(422).json({ errors: errors.array() });
     }
 
-    const {token, password} = req.body;
+    const { token, password } = req.body;
 
     try {
       // Hash the token to compare with stored version
@@ -268,20 +269,20 @@ router.post(
       // Find valid reset record
       const resetRecord = await PasswordReset.findOne({
         token: hashedToken,
-        expiresAt: {$gt: new Date()},
+        expiresAt: { $gt: new Date() },
         used: false,
       });
 
       if (!resetRecord) {
         return res
           .status(400)
-          .json({message: 'Invalid or expired reset token.'});
+          .json({ message: 'Invalid or expired reset token.' });
       }
 
       // Find the user
       const user = await User.findById(resetRecord.userId);
       if (!user) {
-        return res.status(404).json({message: 'User not found.'});
+        return res.status(404).json({ message: 'User not found.' });
       }
 
       // Hash new password
@@ -301,7 +302,7 @@ router.post(
       // Delete all messages for this user (both sent and received)
       // Since messages are encrypted with the old password-derived keys
       await Message.deleteMany({
-        $or: [{senderId: user._id}, {receiverId: user._id}],
+        $or: [{ senderId: user._id }, { receiverId: user._id }],
       });
 
       console.log(
@@ -319,7 +320,7 @@ router.post(
       });
     } catch (error) {
       console.error('[Reset Password Error]', error);
-      res.status(500).json({message: 'Server error during password reset.'});
+      res.status(500).json({ message: 'Server error during password reset.' });
     }
   }
 );


### PR DESCRIPTION
- Replace Google email with Privateemail SMTP (mail.privateemail.com:465)
- Add branded email templates with Quasar dark theme
- Fix password reset URL routing to include /app path
- Remove provider-specific branding from emails
- Add mobile-responsive HTML email layouts
- Fix nested URL bug in password reset token handling