### PR TITLE
feat: auth header navigation

### DIFF
--- a/frontend/src/app/core/services/recaptcha.service.ts
+++ b/frontend/src/app/core/services/recaptcha.service.ts
@@ -70,10 +70,15 @@ export class RecaptchaService {
 
   resetRecaptcha(widgetId?: number): void {
     if (typeof grecaptcha !== 'undefined') {
-      if (widgetId !== undefined) {
-        grecaptcha.reset(widgetId);
-      } else {
-        grecaptcha.reset();
+      try {
+        if (widgetId !== undefined) {
+          grecaptcha.reset(widgetId);
+        } else {
+          grecaptcha.reset();
+        }
+      } catch (error) {
+        // Silently ignore reCAPTCHA reset errors during component destruction
+        console.debug('reCAPTCHA reset error (ignored):', error);
       }
     }
   }

--- a/frontend/src/app/shared/components/header/header.component.html
+++ b/frontend/src/app/shared/components/header/header.component.html
@@ -34,6 +34,29 @@
     </div>
 
     <div class="nav-links" [class.open]="menuOpen">
+      <!-- Auth navigation buttons (only when not authenticated and on auth pages) -->
+      <ng-container *ngIf="!authService.isAuthenticated() && isAuthPage()">
+        <button
+          *ngIf="router.url !== '/auth/register'"
+          mat-button
+          routerLink="/auth/register"
+          (click)="closeMenu()"
+        >
+          <mat-icon>person_add</mat-icon>
+          <span class="mobile-hidden">Create Account</span>
+        </button>
+        
+        <button
+          *ngIf="router.url !== '/auth/login'"
+          mat-button
+          routerLink="/auth/login"
+          (click)="closeMenu()"
+        >
+          <mat-icon>login</mat-icon>
+          <span class="mobile-hidden">Sign In</span>
+        </button>
+      </ng-container>
+
       <!-- Desktop connection status (hidden on mobile) -->
       <div
         *ngIf="authService.isAuthenticated()"

--- a/frontend/src/app/shared/components/header/header.component.html
+++ b/frontend/src/app/shared/components/header/header.component.html
@@ -14,9 +14,10 @@
     </a>
 
     <!-- Mobile controls - status + hamburger button with notification badge -->
-    <div class="mobile-controls" *ngIf="authService.isAuthenticated()">
+    <div class="mobile-controls" *ngIf="authService.isAuthenticated() || (!authService.isAuthenticated() && isAuthPage())">
       <!-- Connection status near hamburger button on mobile -->
       <div
+        *ngIf="authService.isAuthenticated()"
         class="status mobile-status"
         [class.connected]="online"
         [class.disconnected]="!online"

--- a/frontend/src/app/shared/components/header/header.component.ts
+++ b/frontend/src/app/shared/components/header/header.component.ts
@@ -163,6 +163,11 @@ export class HeaderComponent implements OnInit, OnDestroy {
     );
   }
 
+  // Check if user is currently on an auth page
+  isAuthPage(): boolean {
+    return this.router.url.startsWith('/auth');
+  }
+
   ngOnDestroy(): void {
     console.log('[Header] Component destroying');
     this.sub.unsubscribe();


### PR DESCRIPTION
- Show hamburger menu for unauthenticated users on auth pages
- Hide connection status indicator for unauthenticated users
- Provide access to Create Account and Sign In buttons on mobile devices
- Add error handling for reCAPTCHA reset during component destruction  
- Add 'Create Account' and 'Sign In' buttons to header on auth pages
- Show 'Create Account' button on login page
- Show 'Sign In' button on register page
- Buttons only visible when user is not authenticated and on auth routes
- Add isAuthPage() method to detect auth routes
- Mobile responsive with existing menu system