### PR TITLE
feat: dark theme implementation

### DIFF
--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -19,6 +19,7 @@ import { WebSocketService } from '@services/websocket.service';
 import { AuthService } from '@services/auth.service';
 import { CryptoService } from '@services/crypto.service';
 import { VaultService, VAULT_KEYS } from '@services/vault.service';
+import { ThemeService } from '@services/theme.service';
 
 @Component({
   selector: 'app-root',
@@ -45,8 +46,12 @@ export class AppComponent implements OnInit, OnDestroy {
     private authService: AuthService,
     private vault: VaultService,
     private crypto: CryptoService,
-    private cdr: ChangeDetectorRef
-  ) {}
+    private cdr: ChangeDetectorRef,
+    private themeService: ThemeService
+  ) {
+    // Initialize theme service - this will load saved theme from localStorage
+    console.log('[App] Theme service initialized');
+  }
 
   ngOnInit(): void {
     console.log('[App] Component initializing');

--- a/frontend/src/app/core/services/recaptcha.service.ts
+++ b/frontend/src/app/core/services/recaptcha.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { environment } from '@environments/environment';
+import { ThemeService } from './theme.service';
 
 declare const grecaptcha: {
   ready(callback: () => void): void;
@@ -14,6 +15,7 @@ interface RecaptchaOptions {
   callback: (token: string) => void;
   'expired-callback': () => void;
   'error-callback': () => void;
+  theme?: 'light' | 'dark';
 }
 
 @Injectable({
@@ -21,6 +23,8 @@ interface RecaptchaOptions {
 })
 export class RecaptchaService {
   private siteKey = environment.recaptchaSiteKey;
+
+  constructor(private themeService: ThemeService) {}
 
   getSiteKey(): string {
     return this.siteKey;
@@ -54,18 +58,26 @@ export class RecaptchaService {
       throw new Error('reCAPTCHA not loaded');
     }
 
-    return grecaptcha.render(elementId, {
-      sitekey: this.siteKey,
-      callback: callback,
-      'expired-callback': () => {
-        // Handle token expiration
-        console.log('reCAPTCHA token expired');
-      },
-      'error-callback': () => {
-        // Handle errors
-        console.error('reCAPTCHA error occurred');
-      },
-    });
+    const currentTheme = this.themeService.getCurrentTheme();
+    const recaptchaTheme = currentTheme === 'dark' ? 'dark' : 'light';
+
+    try {
+      return grecaptcha.render(elementId, {
+        sitekey: this.siteKey,
+        callback: callback,
+        theme: recaptchaTheme,
+        'expired-callback': () => {
+          console.log('reCAPTCHA token expired');
+        },
+        'error-callback': () => {
+          console.error('reCAPTCHA error occurred');
+          // Don't throw error, just log it to prevent app crashes
+        }
+      });
+    } catch (error) {
+      console.error('Failed to render reCAPTCHA:', error);
+      throw error;
+    }
   }
 
   resetRecaptcha(widgetId?: number): void {
@@ -93,5 +105,29 @@ export class RecaptchaService {
     } else {
       return grecaptcha.getResponse();
     }
+  }
+
+  /**
+   * Re-render reCAPTCHA with current theme when theme changes
+   */
+  reRenderWithTheme(
+    elementId: string, 
+    callback: (token: string) => void,
+    currentWidgetId?: number
+  ): Promise<number> {
+    return new Promise((resolve) => {
+      // Reset the current widget if it exists
+      if (currentWidgetId !== undefined) {
+        console.log('Resetting reCAPTCHA widget:', currentWidgetId);
+        this.resetRecaptcha(currentWidgetId);
+      }
+
+      // Wait a bit for the reset to complete before rendering new widget
+      setTimeout(() => {
+        console.log('Rendering new reCAPTCHA with theme');
+        const newWidgetId = this.renderRecaptcha(elementId, callback);
+        resolve(newWidgetId);
+      }, 150);
+    });
   }
 }

--- a/frontend/src/app/core/services/theme.service.ts
+++ b/frontend/src/app/core/services/theme.service.ts
@@ -7,7 +7,7 @@ export type Theme = 'light' | 'dark';
   providedIn: 'root',
 })
 export class ThemeService {
-  private currentTheme: Theme = 'light';
+  private currentTheme: Theme = 'dark';
   private themeSubject = new BehaviorSubject<Theme>(this.currentTheme);
 
   public theme$ = this.themeSubject.asObservable();
@@ -27,7 +27,7 @@ export class ThemeService {
       const prefersDark = window.matchMedia(
         '(prefers-color-scheme: dark)'
       ).matches;
-      this.currentTheme = prefersDark ? 'dark' : 'light';
+      this.currentTheme = prefersDark ? 'dark' : 'dark';
     }
 
     this.applyTheme(this.currentTheme);

--- a/frontend/src/app/core/services/theme.service.ts
+++ b/frontend/src/app/core/services/theme.service.ts
@@ -1,0 +1,83 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+export type Theme = 'light' | 'dark';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ThemeService {
+  private currentTheme: Theme = 'light';
+  private themeSubject = new BehaviorSubject<Theme>(this.currentTheme);
+
+  public theme$ = this.themeSubject.asObservable();
+
+  constructor() {
+    this.initializeTheme();
+  }
+
+  private initializeTheme(): void {
+    // Check localStorage first
+    const savedTheme = localStorage.getItem('theme') as Theme;
+
+    if (savedTheme && (savedTheme === 'light' || savedTheme === 'dark')) {
+      this.currentTheme = savedTheme;
+    } else {
+      // Check system preference
+      const prefersDark = window.matchMedia(
+        '(prefers-color-scheme: dark)'
+      ).matches;
+      this.currentTheme = prefersDark ? 'dark' : 'light';
+    }
+
+    this.applyTheme(this.currentTheme);
+    this.themeSubject.next(this.currentTheme);
+  }
+
+  public getCurrentTheme(): Theme {
+    return this.currentTheme;
+  }
+
+  public toggleTheme(): void {
+    const newTheme: Theme = this.currentTheme === 'light' ? 'dark' : 'light';
+    this.setTheme(newTheme);
+  }
+
+  public setTheme(theme: Theme): void {
+    console.log('[ThemeService] Setting theme to:', theme);
+    this.currentTheme = theme;
+    this.applyTheme(theme);
+    this.saveTheme(theme);
+    this.themeSubject.next(theme);
+    console.log('[ThemeService] Theme change emitted');
+  }
+
+  private applyTheme(theme: Theme): void {
+    const root = document.documentElement;
+
+    // Remove existing theme classes
+    root.classList.remove('light-theme', 'dark-theme');
+
+    // Add new theme class
+    root.classList.add(`${theme}-theme`);
+
+    // Update theme-color meta tag for mobile browsers
+    const themeColorMeta = document.querySelector('meta[name="theme-color"]');
+    if (themeColorMeta) {
+      const themeColor = theme === 'dark' ? '#0c2524' : '#0077cc';
+      themeColorMeta.setAttribute('content', themeColor);
+    }
+  }
+
+  private saveTheme(theme: Theme): void {
+    localStorage.setItem('theme', theme);
+  }
+
+  public isDarkTheme(): boolean {
+    return this.currentTheme === 'dark';
+  }
+
+  public isLightTheme(): boolean {
+    return this.currentTheme === 'light';
+  }
+}

--- a/frontend/src/app/features/auth/forgot-password/forgot-password.component.css
+++ b/frontend/src/app/features/auth/forgot-password/forgot-password.component.css
@@ -7,7 +7,6 @@
   overflow: hidden;
 }
 
-
 .auth-card {
   width: 100%;
   max-width: 420px;
@@ -217,10 +216,6 @@
 
 .button-spinner {
   margin-right: 10px;
-
-  ::ng-deep circle {
-    stroke: #fff;
-  }
 }
 
 /* Success message */

--- a/frontend/src/app/features/auth/forgot-password/forgot-password.component.css
+++ b/frontend/src/app/features/auth/forgot-password/forgot-password.component.css
@@ -7,39 +7,13 @@
   overflow: hidden;
 }
 
-.auth-container::before {
-  content: "";
-  position: absolute;
-  bottom: -50%;
-  right: -50%;
-  width: 200%;
-  height: 200%;
-  background: radial-gradient(
-    circle,
-    rgba(255, 255, 255, 0.1) 0%,
-    transparent 70%
-  );
-  animation: pulse 20s ease-in-out infinite;
-}
-
-@keyframes pulse {
-  0%,
-  100% {
-    transform: scale(1);
-    opacity: 0.5;
-  }
-  50% {
-    transform: scale(1.1);
-    opacity: 0.3;
-  }
-}
 
 .auth-card {
   width: 100%;
   max-width: 420px;
-  background: white;
+  background: var(--card-background);
   border-radius: 16px;
-  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-md);
   overflow: hidden;
   position: relative;
   z-index: 1;
@@ -60,7 +34,7 @@
 .auth-header {
   padding: var(--spacing-xl) var(--spacing-lg) var(--spacing-lg);
   text-align: center;
-  background: linear-gradient(to bottom, #f8f9fa, white);
+  background: var(--card-background);
 }
 
 .auth-header h1 {
@@ -73,7 +47,7 @@
 
 .auth-header p {
   margin: 0;
-  color: #666;
+  color: var(--text-secondary);
   font-size: 0.95rem;
 }
 
@@ -95,7 +69,7 @@
 }
 
 ::ng-deep .auth-container .mat-mdc-text-field-wrapper {
-  /* background-color: #f8f9fa; */
+  background-color: var(--input-background);
   border-radius: 12px;
   transition: all 0.3s ease;
 }
@@ -104,8 +78,7 @@
   .auth-container
   .mat-mdc-form-field.mat-focused
   .mat-mdc-text-field-wrapper {
-  background-color: white;
-  /* box-shadow: 0 0 0 2px rgba(255, 152, 0, 0.2); */
+  background-color: var(--card-background);
 }
 
 ::ng-deep .auth-container .mat-mdc-form-field-error {
@@ -114,12 +87,12 @@
 }
 
 ::ng-deep .auth-container .mat-mdc-floating-label {
-  color: #666 !important;
+  color: var(--text-secondary) !important;
 }
 
 /* Input icons */
 ::ng-deep .auth-container .mat-mdc-form-field-icon-prefix {
-  color: #999;
+  color: var(--text-secondary);
   margin-right: 8px;
 }
 
@@ -135,13 +108,13 @@
   display: flex;
   align-items: flex-start;
   gap: var(--spacing-sm);
-  background-color: #fff3e0;
-  color: #e65100;
+  background-color: var(--warning-background);
+  color: var(--warning-text);
   padding: var(--spacing-md);
   border-radius: 8px;
+  border: 1px solid var(--border-color);
   margin-bottom: var(--spacing-lg);
   font-size: 0.85rem;
-  border: 1px solid #ffcc80;
 }
 
 .warning-box mat-icon {
@@ -160,10 +133,11 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  background-color: #ffebee;
+  background-color: rgba(244, 67, 54, 0.1);
   color: var(--danger-color);
   padding: var(--spacing-md);
   border-radius: 8px;
+  border: 1px solid var(--border-color);
   margin-bottom: var(--spacing-md);
   font-size: 0.9rem;
   animation: shake 0.5s ease-out;
@@ -238,7 +212,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--button-text);
 }
 
 .button-spinner {
@@ -271,7 +245,7 @@
 
 .success-message p {
   margin: 0 0 var(--spacing-md);
-  color: #666;
+  color: var(--text-secondary);
   line-height: 1.5;
 }
 
@@ -282,7 +256,7 @@
 .success-message .spam-note {
   font-size: 0.85rem;
   font-style: italic;
-  color: #999;
+  color: var(--text-secondary);
   margin-bottom: var(--spacing-xl);
 }
 
@@ -304,12 +278,12 @@
   text-align: center;
   margin-top: var(--spacing-xl);
   padding-top: var(--spacing-lg);
-  border-top: 1px solid #f0f0f0;
+  border-top: 1px solid var(--border-color);
 }
 
 .auth-footer p {
   margin: 0;
-  color: #666;
+  color: var(--text-secondary);
   font-size: 0.9rem;
 }
 

--- a/frontend/src/app/features/auth/login/login.component.css
+++ b/frontend/src/app/features/auth/login/login.component.css
@@ -7,7 +7,6 @@
   overflow: hidden;
 }
 
-
 .auth-card {
   width: 100%;
   max-width: 420px;
@@ -214,10 +213,6 @@
 
 .button-spinner {
   margin-right: 10px;
-
-  ::ng-deep circle {
-    stroke: #fff;
-  }
 }
 
 .auth-footer {

--- a/frontend/src/app/features/auth/login/login.component.css
+++ b/frontend/src/app/features/auth/login/login.component.css
@@ -7,39 +7,13 @@
   overflow: hidden;
 }
 
-.auth-container::before {
-  content: "";
-  position: absolute;
-  top: -50%;
-  right: -50%;
-  width: 200%;
-  height: 200%;
-  background: radial-gradient(
-    circle,
-    rgba(255, 255, 255, 0.1) 0%,
-    transparent 70%
-  );
-  animation: pulse 20s ease-in-out infinite;
-}
-
-@keyframes pulse {
-  0%,
-  100% {
-    transform: scale(1);
-    opacity: 0.5;
-  }
-  50% {
-    transform: scale(1.1);
-    opacity: 0.3;
-  }
-}
 
 .auth-card {
   width: 100%;
   max-width: 420px;
-  background: white;
+  background: var(--card-background);
   border-radius: 16px;
-  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-md);
   overflow: hidden;
   position: relative;
   z-index: 1;
@@ -60,7 +34,7 @@
 .auth-header {
   padding: var(--spacing-xl) var(--spacing-lg) var(--spacing-lg);
   text-align: center;
-  background: linear-gradient(to bottom, #f8f9fa, white);
+  background: var(--card-background);
 }
 
 .auth-header h1 {
@@ -73,7 +47,7 @@
 
 .auth-header p {
   margin: 0;
-  color: #666;
+  color: var(--text-secondary);
   font-size: 0.95rem;
 }
 
@@ -104,7 +78,7 @@
   .auth-container
   .mat-mdc-form-field.mat-focused
   .mat-mdc-text-field-wrapper {
-  background-color: white;
+  background-color: var(--input-background);
 }
 
 ::ng-deep .auth-container .mat-mdc-form-field-error {
@@ -113,12 +87,12 @@
 }
 
 ::ng-deep .auth-container .mat-mdc-floating-label {
-  color: #666 !important;
+  color: var(--text-secondary) !important;
 }
 
 /* Input icons */
 ::ng-deep .auth-container .mat-mdc-form-field-icon-prefix {
-  color: #999;
+  color: var(--text-secondary);
   margin-right: 8px;
 }
 
@@ -152,10 +126,11 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  background-color: #ffebee;
+  background-color: rgba(244, 67, 54, 0.1);
   color: var(--danger-color);
   padding: var(--spacing-md);
   border-radius: 8px;
+  border: 1px solid rgba(244, 67, 54, 0.2);
   margin-bottom: var(--spacing-md);
   font-size: 0.9rem;
   animation: shake 0.5s ease-out;
@@ -213,12 +188,12 @@
     var(--primary-color),
     var(--secondary-color)
   );
-  box-shadow: 0 4px 12px rgba(0, 119, 204, 0.3);
+  box-shadow: 0 4px 12px rgba(var(--primary-color-rgb), 0.3);
 }
 
 .submit-button:not(:disabled):hover {
   transform: translateY(-1px);
-  box-shadow: 0 6px 20px rgba(0, 119, 204, 0.4);
+  box-shadow: 0 6px 20px rgba(var(--primary-color-rgb), 0.4);
 }
 
 .submit-button:not(:disabled):active {
@@ -234,7 +209,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--button-text);
 }
 
 .button-spinner {
@@ -249,12 +224,12 @@
   text-align: center;
   margin-top: var(--spacing-xl);
   padding-top: var(--spacing-lg);
-  border-top: 1px solid #f0f0f0;
+  border-top: 1px solid var(--border-color);
 }
 
 .auth-footer p {
   margin: 0;
-  color: #666;
+  color: var(--text-secondary);
   font-size: 0.9rem;
 }
 

--- a/frontend/src/app/features/auth/register/register.component.css
+++ b/frontend/src/app/features/auth/register/register.component.css
@@ -7,7 +7,6 @@
   overflow: hidden;
 }
 
-
 .auth-card {
   width: 100%;
   max-width: 420px;
@@ -282,10 +281,6 @@
 
 .button-spinner {
   margin-right: 10px;
-
-  ::ng-deep circle {
-    stroke: #fff;
-  }
 }
 
 .auth-footer {

--- a/frontend/src/app/features/auth/register/register.component.css
+++ b/frontend/src/app/features/auth/register/register.component.css
@@ -7,39 +7,13 @@
   overflow: hidden;
 }
 
-.auth-container::before {
-  content: "";
-  position: absolute;
-  top: -50%;
-  left: -50%;
-  width: 200%;
-  height: 200%;
-  background: radial-gradient(
-    circle,
-    rgba(255, 255, 255, 0.1) 0%,
-    transparent 70%
-  );
-  animation: pulse 20s ease-in-out infinite;
-}
-
-@keyframes pulse {
-  0%,
-  100% {
-    transform: scale(1);
-    opacity: 0.5;
-  }
-  50% {
-    transform: scale(1.1);
-    opacity: 0.3;
-  }
-}
 
 .auth-card {
   width: 100%;
   max-width: 420px;
-  background: white;
+  background: var(--card-background);
   border-radius: 16px;
-  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-md);
   overflow: hidden;
   position: relative;
   z-index: 1;
@@ -60,7 +34,7 @@
 .auth-header {
   padding: var(--spacing-xl) var(--spacing-lg) var(--spacing-lg);
   text-align: center;
-  background: linear-gradient(to bottom, #f8f9fa, white);
+  background: var(--card-background);
 }
 
 .auth-header h1 {
@@ -73,7 +47,7 @@
 
 .auth-header p {
   margin: 0;
-  color: #666;
+  color: var(--text-secondary);
   font-size: 0.95rem;
 }
 
@@ -95,7 +69,7 @@
 }
 
 ::ng-deep .auth-container .mat-mdc-text-field-wrapper {
-  /* background-color: #f8f9fa; */
+  background-color: var(--input-background);
   border-radius: 12px;
   transition: all 0.3s ease;
 }
@@ -104,7 +78,7 @@
   .auth-container
   .mat-mdc-form-field.mat-focused
   .mat-mdc-text-field-wrapper {
-  background-color: white;
+  background-color: var(--card-background);
 }
 
 ::ng-deep .auth-container .mat-mdc-form-field-error {
@@ -113,12 +87,12 @@
 }
 
 ::ng-deep .auth-container .mat-mdc-floating-label {
-  color: #666 !important;
+  color: var(--text-secondary) !important;
 }
 
 /* Input icons */
 ::ng-deep .auth-container .mat-mdc-form-field-icon-prefix {
-  color: #999;
+  color: var(--text-secondary);
   margin-right: 8px;
 }
 
@@ -132,7 +106,7 @@
 /* Hints */
 ::ng-deep .auth-container .mat-mdc-form-field-hint {
   font-size: 0.75rem;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .hint-valid {
@@ -147,7 +121,7 @@
 
 .strength-label {
   font-size: 0.8rem;
-  color: #666;
+  color: var(--text-secondary);
   margin-bottom: var(--spacing-xs);
 }
 
@@ -199,10 +173,11 @@
   display: flex;
   align-items: flex-start;
   gap: var(--spacing-sm);
-  background-color: #e3f2fd;
-  color: #0d47a1;
+  background-color: var(--info-background);
+  color: var(--info-text);
   padding: var(--spacing-md);
   border-radius: 8px;
+  border: 1px solid var(--border-color);
   margin-bottom: var(--spacing-md);
   font-size: 0.85rem;
 }
@@ -223,10 +198,11 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  background-color: #ffebee;
+  background-color: rgba(244, 67, 54, 0.1);
   color: var(--danger-color);
   padding: var(--spacing-md);
   border-radius: 8px;
+  border: 1px solid var(--border-color);
   margin-bottom: var(--spacing-md);
   font-size: 0.9rem;
   animation: shake 0.5s ease-out;
@@ -301,7 +277,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--button-text);
 }
 
 .button-spinner {
@@ -316,12 +292,12 @@
   text-align: center;
   margin-top: var(--spacing-xl);
   padding-top: var(--spacing-lg);
-  border-top: 1px solid #f0f0f0;
+  border-top: 1px solid var(--border-color);
 }
 
 .auth-footer p {
   margin: 0;
-  color: #666;
+  color: var(--text-secondary);
   font-size: 0.9rem;
 }
 

--- a/frontend/src/app/features/auth/register/register.component.ts
+++ b/frontend/src/app/features/auth/register/register.component.ts
@@ -6,6 +6,7 @@ import {
   ElementRef,
   ViewChild,
 } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { Router, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
@@ -20,6 +21,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { AuthService } from '@services/auth.service';
 import { LoadingService } from '@services/loading.service';
 import { RecaptchaService } from '@services/recaptcha.service';
+import { ThemeService } from '@services/theme.service';
 import { defaultAvatarFor } from '@utils/avatar.util';
 
 interface ValidationError {
@@ -57,6 +59,7 @@ export class RegisterComponent implements OnInit, OnDestroy, AfterViewInit {
   formSubmitted = false;
   recaptchaToken = '';
   recaptchaWidgetId: number | undefined;
+  private themeSubscription?: Subscription;
 
   constructor(
     private authService: AuthService,

--- a/frontend/src/app/features/auth/reset-password/reset-password.component.css
+++ b/frontend/src/app/features/auth/reset-password/reset-password.component.css
@@ -21,51 +21,25 @@
     var(--primary-color),
     var(--secondary-color)
   );
-  box-shadow: 0 4px 12px rgba(0, 119, 204, 0.3);
+  box-shadow: 0 4px 12px rgba(var(--primary-color-rgb), 0.3);
 }
 
 .submit-button:not(:disabled):hover {
   transform: translateY(-1px);
-  box-shadow: 0 6px 20px rgba(0, 119, 204, 0.4);
+  box-shadow: 0 6px 20px rgba(var(--primary-color-rgb), 0.4);
 }
 
 .full-width {
   width: 100%;
 }
 
-.auth-container::before {
-  content: "";
-  position: absolute;
-  top: -50%;
-  left: -50%;
-  width: 200%;
-  height: 200%;
-  background: radial-gradient(
-    circle,
-    rgba(255, 255, 255, 0.1) 0%,
-    transparent 70%
-  );
-  animation: pulse 20s ease-in-out infinite;
-}
-
-@keyframes pulse {
-  0%,
-  100% {
-    transform: scale(1);
-    opacity: 0.5;
-  }
-  50% {
-    transform: scale(1.1);
-    opacity: 0.3;
-  }
-}
 
 .auth-card {
   width: 100%;
   max-width: 420px;
-  background: white;
+  background: var(--card-background);
   border-radius: 16px;
-  box-shadow: 0 10px 40px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--shadow-md);
   overflow: hidden;
   position: relative;
   z-index: 1;
@@ -86,7 +60,7 @@
 .auth-header {
   padding: var(--spacing-xl) var(--spacing-lg) var(--spacing-lg);
   text-align: center;
-  background: linear-gradient(to bottom, #f8f9fa, white);
+  background: var(--card-background);
 }
 
 .auth-header h1 {
@@ -99,7 +73,7 @@
 
 .auth-header p {
   margin: 0;
-  color: #666;
+  color: var(--text-secondary);
   font-size: 0.95rem;
 }
 
@@ -121,6 +95,7 @@
 }
 
 ::ng-deep .auth-container .mat-mdc-text-field-wrapper {
+  background-color: var(--input-background);
   border-radius: 12px;
   transition: all 0.3s ease;
 }
@@ -129,7 +104,7 @@
   .auth-container
   .mat-mdc-form-field.mat-focused
   .mat-mdc-text-field-wrapper {
-  background-color: white;
+  background-color: var(--card-background);
 }
 
 ::ng-deep .auth-container .mat-mdc-form-field-error {
@@ -138,12 +113,12 @@
 }
 
 ::ng-deep .auth-container .mat-mdc-floating-label {
-  color: #666 !important;
+  color: var(--text-secondary) !important;
 }
 
 /* Input icons */
 ::ng-deep .auth-container .mat-mdc-form-field-icon-prefix {
-  color: #999;
+  color: var(--text-secondary);
   margin-right: 8px;
 }
 
@@ -157,7 +132,7 @@
 /* Hints */
 ::ng-deep .auth-container .mat-mdc-form-field-hint {
   font-size: 0.75rem;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .hint-valid {
@@ -172,7 +147,7 @@
 
 .strength-label {
   font-size: 0.8rem;
-  color: #666;
+  color: var(--text-secondary);
   margin-bottom: var(--spacing-xs);
 }
 
@@ -224,13 +199,13 @@
   display: flex;
   align-items: flex-start;
   gap: var(--spacing-sm);
-  background-color: #e1f5fe;
-  color: #0277bd;
+  background-color: var(--info-background);
+  color: var(--info-text);
   padding: var(--spacing-md);
   border-radius: 8px;
+  border: 1px solid var(--border-color);
   margin-bottom: var(--spacing-lg);
   font-size: 0.85rem;
-  border: 1px solid #81d4fa;
 }
 
 .warning-box mat-icon {
@@ -249,10 +224,11 @@
   display: flex;
   align-items: center;
   gap: var(--spacing-sm);
-  background-color: #ffebee;
+  background-color: rgba(244, 67, 54, 0.1);
   color: var(--danger-color);
   padding: var(--spacing-md);
   border-radius: 8px;
+  border: 1px solid var(--border-color);
   margin-bottom: var(--spacing-md);
   font-size: 0.9rem;
   animation: shake 0.5s ease-out;
@@ -327,7 +303,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--button-text);
 }
 
 .button-spinner {
@@ -384,7 +360,7 @@
 .success-message p,
 .error-message p {
   margin: 0 0 var(--spacing-md);
-  color: #666;
+  color: var(--text-secondary);
   line-height: 1.5;
 }
 
@@ -406,12 +382,12 @@
   text-align: center;
   margin-top: var(--spacing-xl);
   padding-top: var(--spacing-lg);
-  border-top: 1px solid #f0f0f0;
+  border-top: 1px solid var(--border-color);
 }
 
 .auth-footer p {
   margin: 0;
-  color: #666;
+  color: var(--text-secondary);
   font-size: 0.9rem;
 }
 

--- a/frontend/src/app/features/auth/reset-password/reset-password.component.css
+++ b/frontend/src/app/features/auth/reset-password/reset-password.component.css
@@ -33,7 +33,6 @@
   width: 100%;
 }
 
-
 .auth-card {
   width: 100%;
   max-width: 420px;
@@ -308,10 +307,6 @@
 
 .button-spinner {
   margin-right: 10px;
-
-  ::ng-deep circle {
-    stroke: #fff;
-  }
 }
 
 .request-button {

--- a/frontend/src/app/features/chat/chat-list/chat-list.component.css
+++ b/frontend/src/app/features/chat/chat-list/chat-list.component.css
@@ -9,9 +9,14 @@
 .chat-header {
   display: flex;
   align-items: center;
-  margin-bottom: var(--spacing-md);
   padding: var(--spacing-md) 0;
-  border-bottom: 1px solid var(--border-color);
+}
+
+/* Large screen spacing */
+@media (min-width: 1200px) {
+  .chat-header {
+    padding: var(--spacing-lg) 0;
+  }
 }
 
 .back-button {
@@ -217,7 +222,6 @@
 
 @media (max-width: 599px) {
   .chat-header {
-    margin-bottom: var(--spacing-md);
     padding: var(--spacing-sm) 0;
   }
 

--- a/frontend/src/app/features/chat/chat-list/chat-list.component.css
+++ b/frontend/src/app/features/chat/chat-list/chat-list.component.css
@@ -29,7 +29,7 @@
 }
 
 .back-button:hover {
-  background-color: rgba(0, 0, 0, 0.05);
+  background-color: var(--nav-hover);
 }
 
 .back-button mat-icon {
@@ -56,7 +56,7 @@
 
 .empty-hint {
   text-align: center;
-  color: #777;
+  color: var(--text-secondary);
   margin-top: var(--spacing-xl);
   padding: var(--spacing-lg);
 }
@@ -69,10 +69,7 @@
   list-style: none;
   padding: 0;
   margin: 0;
-  border-radius: var(--border-radius);
   overflow: hidden;
-  box-shadow: var(--shadow-sm);
-  background-color: white;
 }
 
 .search-results span {
@@ -85,7 +82,8 @@
   width: 100%;
   padding: var(--spacing-md);
   border: none;
-  background: white;
+  background: var(--card-background);
+  color: var(--text-color);
   text-align: left;
   cursor: pointer;
   transition: background-color 0.2s;
@@ -93,7 +91,7 @@
 }
 
 .search-result-btn:hover {
-  background-color: #f5f7fa;
+  background-color: var(--nav-hover);
 }
 
 .search-result-btn img {
@@ -108,10 +106,10 @@
   list-style: none;
   padding: 0;
   margin: 0;
-  border-radius: var(--border-radius);
   overflow: hidden;
   box-shadow: var(--shadow-sm);
-  background-color: white;
+  background-color: var(--chat-list-background);
+  border-radius: var(--border-radius);
 }
 
 .chat-list li {
@@ -127,13 +125,13 @@
   align-items: center;
   padding: var(--spacing-md);
   text-decoration: none;
-  color: inherit;
+  color: var(--text-color);
   transition: background-color 0.2s;
   min-height: 60px;
 }
 
 .chat-list a:hover {
-  background-color: #f5f7fa;
+  background-color: var(--nav-hover);
 }
 
 .avatar {
@@ -164,14 +162,14 @@
 
 .time {
   font-size: 0.75rem;
-  color: #666;
+  color: var(--text-secondary);
 }
 
 .last-message {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  color: #666;
+  color: var(--text-secondary);
   font-size: 0.875rem;
   max-width: 70vw;
   margin: 0;
@@ -181,7 +179,7 @@
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background: #ccc;
+  background: var(--text-secondary);
   margin-right: var(--spacing-md);
   flex-shrink: 0;
   display: inline-block;
@@ -208,7 +206,7 @@
 }
 
 ::ng-deep .mat-mdc-text-field-wrapper {
-  background-color: white !important;
+  background-color: var(--input-background) !important;
 }
 
 @media (max-width: 768px) {

--- a/frontend/src/app/features/chat/chat-room/chat-room.component.css
+++ b/frontend/src/app/features/chat/chat-room/chat-room.component.css
@@ -214,7 +214,7 @@
 }
 
 .message.other {
-  background-color: var(--input-background);
+  background-color: #f1f3f4;
   color: var(--text-color);
   align-self: flex-start;
   border-bottom-left-radius: 4px;
@@ -285,19 +285,25 @@
 
 /* Enhanced typing indicator positioning and styling - Desktop version */
 .typing-indicator {
-  background: var(--card-background);
+  background: #f8f9fa;
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   padding: var(--spacing-sm) var(--spacing-md);
-  border-top: 1px solid var(--border-color);
-  border-radius: 12px 12px 0 0;
   font-style: italic;
   color: var(--text-secondary);
   font-size: 0.85rem;
   text-align: left;
-  z-index: 10;
-  box-shadow: var(--shadow-sm);
+  z-index: 15;
   animation: fadeInUp 0.3s ease-out;
+  position: relative;
+  margin-bottom: 0;
+  flex-shrink: 0;
+  order: 2;
+}
+
+/* Dark theme typing indicator background */
+.dark-theme .typing-indicator {
+  background: #0b1e1e;
 }
 
 /* Add typing animation dots */
@@ -395,6 +401,7 @@
   position: relative;
   z-index: 3;
   flex-shrink: 0;
+  order: 3;
 }
 
 .message-input {
@@ -513,7 +520,11 @@
 }
 
 .message.you.unreadable {
-  background-color: #e3f2fd !important;
+  background-color: #f9f9f9 !important;
+}
+
+.message.other.unreadable {
+  background-color: #f9f9f9 !important;
 }
 
 /* Dark theme styling for unreadable messages */
@@ -527,7 +538,15 @@
 }
 
 .dark-theme .message.you.unreadable {
-  background-color: rgba(195, 247, 58, 0.1) !important;
+  background-color: #0b1e1e !important;
+}
+
+.dark-theme .message.other {
+  background-color: rgba(104, 182, 132, 0.15) !important;
+}
+
+.dark-theme .message.other.unreadable {
+  background-color: #0b1e1e !important;
 }
 
 /* Fix message time and status visibility for unreadable messages */
@@ -606,9 +625,20 @@
   display: flex;
 }
 
+@media (max-width: 1024px) {
+  .chat-wrapper {
+    height: calc(
+      100vh - var(--header-height) - var(--footer-height) - var(--spacing-xl)
+    );
+  }
+}
+
 @media (max-width: 768px) {
   .chat-wrapper {
     padding: 0 var(--spacing-md);
+    height: calc(
+      100vh - var(--header-height) - var(--footer-height) - var(--spacing-md)
+    );
   }
 }
 
@@ -664,6 +694,7 @@
     height: calc(100vh - var(--header-height) - 60px - 80px);
     overflow-y: auto;
     position: relative;
+    padding-bottom: 100px;
   }
 
   .chat-form {
@@ -712,22 +743,23 @@
     position: fixed !important;
     left: 0;
     right: 0;
-    bottom: calc(70px + env(safe-area-inset-bottom, 0px));
-    background: var(--card-background);
+    bottom: calc(80px + env(safe-area-inset-bottom, 0px));
+    background: #f8f9fa;
     backdrop-filter: blur(10px);
     -webkit-backdrop-filter: blur(10px);
     padding: var(--spacing-xs) var(--spacing-md);
     margin: 0;
-    border-top: 1px solid var(--border-color);
-    border-bottom: 1px solid var(--border-color);
-    border-radius: 0;
     font-style: italic;
     color: var(--text-secondary);
     font-size: 0.8rem;
     text-align: left;
     z-index: 1001;
-    box-shadow: var(--shadow-sm);
     animation: fadeInUp 0.3s ease-out;
+  }
+
+  /* Dark theme mobile typing indicator background */
+  .dark-theme .typing-indicator {
+    background: #0b1e1e;
   }
 
   /* Fix iOS overscroll behavior */

--- a/frontend/src/app/features/chat/chat-room/chat-room.component.css
+++ b/frontend/src/app/features/chat/chat-room/chat-room.component.css
@@ -527,6 +527,17 @@
   background-color: #f9f9f9 !important;
 }
 
+/* Encrypted messages from partner - same styling as unreadable */
+.message.other.encrypted {
+  background-color: #f9f9f9 !important;
+  opacity: 0.85;
+}
+
+.message.other.encrypted .message-content {
+  font-style: italic;
+  color: #6c757d;
+}
+
 /* Dark theme styling for unreadable messages */
 .dark-theme .message.unreadable {
   background-color: rgba(255, 255, 255, 0.05) !important;
@@ -547,6 +558,16 @@
 
 .dark-theme .message.other.unreadable {
   background-color: #0b1e1e !important;
+}
+
+/* Dark theme encrypted messages from partner */
+.dark-theme .message.other.encrypted {
+  background-color: #0b1e1e !important;
+  opacity: 0.7;
+}
+
+.dark-theme .message.other.encrypted .message-content {
+  color: var(--text-secondary) !important;
 }
 
 /* Fix message time and status visibility for unreadable messages */
@@ -682,10 +703,6 @@
   /* Dark theme mobile chat-header */
   .dark-theme .chat-header {
     background-color: #001011 !important;
-  }
-
-  .chat-container app-cache-info-banner {
-    /* Let the banner component handle its own positioning */
   }
 
   .chat-window {

--- a/frontend/src/app/features/chat/chat-room/chat-room.component.css
+++ b/frontend/src/app/features/chat/chat-room/chat-room.component.css
@@ -11,12 +11,12 @@
   flex-direction: column;
   height: calc(100vh - var(--header-height) - var(--footer-height) - 32px);
   width: 100%;
-  border-radius: var(--border-radius);
-  background-color: white;
-  box-shadow: var(--shadow-sm);
   overflow: hidden;
   z-index: 1;
   box-sizing: border-box;
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow-sm);
+  background-color: var(--card-background);
 }
 
 .chat-header {
@@ -24,8 +24,9 @@
   align-items: center;
   padding: var(--spacing-md) 0;
   border-bottom: 1px solid var(--border-color);
-  background-color: #f8f9fa;
   justify-content: space-between;
+  background: transparent;
+  margin-bottom: var(--spacing-md);
 }
 
 /* Left side: back button + user info */
@@ -57,7 +58,7 @@
 }
 
 .back-button:hover {
-  background-color: rgba(0, 0, 0, 0.05);
+  background-color: var(--nav-hover);
 }
 
 .back-button mat-icon {
@@ -74,6 +75,7 @@
 .user-info h3 {
   font-size: larger;
   margin: 0;
+  color: var(--text-color);
 }
 
 .avatar {
@@ -88,11 +90,12 @@
   font-weight: 600;
   margin: 0;
   margin-bottom: 4px;
+  color: var(--text-color);
 }
 
 .status {
   font-size: 0.75rem;
-  color: #666;
+  color: var(--text-secondary);
   display: flex;
   align-items: center;
   gap: 8px;
@@ -110,7 +113,7 @@
 }
 
 .status-dot.offline {
-  background-color: #ccc;
+  background-color: var(--text-secondary);
 }
 
 .chat-window {
@@ -135,7 +138,7 @@
 }
 
 .messages-loading p {
-  color: #666;
+  color: var(--text-secondary);
   font-size: 0.9rem;
   margin: 0;
 }
@@ -160,16 +163,16 @@
 }
 
 .date-text {
-  background-color: white;
+  background-color: var(--card-background);
   padding: var(--spacing-xs) var(--spacing-md);
   border: 1px solid var(--border-color);
   border-radius: 20px;
   font-size: 0.8rem;
   font-weight: 500;
-  color: #666;
+  color: var(--text-secondary);
   z-index: 2;
   position: relative;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-sm);
 }
 
 /* Reduce spacing for first date header */
@@ -190,22 +193,22 @@
 
 .message.you {
   background-color: var(--primary-color);
-  color: white;
+  color: var(--button-text);
   align-self: flex-end;
   margin-left: auto;
   border-bottom-right-radius: 4px;
 }
 
 .message.other {
-  background-color: #f1f1f1;
-  color: #333;
+  background-color: var(--input-background);
+  color: var(--text-color);
   align-self: flex-start;
   border-bottom-left-radius: 4px;
 }
 
 .message.deleted {
-  background-color: #eee;
-  color: #888;
+  background-color: var(--border-color);
+  color: var(--text-secondary);
   font-style: italic;
 }
 
@@ -238,7 +241,7 @@
   top: -20px;
   right: 0;
   display: none;
-  background-color: white;
+  background-color: var(--card-background);
   border-radius: 12px;
   box-shadow: var(--shadow-sm);
   z-index: 2;
@@ -254,7 +257,7 @@
   font-size: 0.8rem;
   padding: 4px 8px;
   cursor: pointer;
-  color: #666;
+  color: var(--text-secondary);
   min-height: 44px;
   min-width: 44px;
   display: flex;
@@ -268,18 +271,18 @@
 
 /* Enhanced typing indicator positioning and styling - Desktop version */
 .typing-indicator {
-  background: rgba(255, 255, 255, 0.95);
+  background: var(--card-background);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   padding: var(--spacing-sm) var(--spacing-md);
   border-top: 1px solid var(--border-color);
   border-radius: 12px 12px 0 0;
   font-style: italic;
-  color: #666;
+  color: var(--text-secondary);
   font-size: 0.85rem;
   text-align: left;
   z-index: 10;
-  box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-sm);
   animation: fadeInUp 0.3s ease-out;
 }
 
@@ -329,18 +332,18 @@
   height: 48px;
   border-radius: 50%;
   background: var(--primary-color);
-  color: white;
+  color: var(--button-text);
   border: none;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 4px 12px rgba(0, 119, 204, 0.3);
+  box-shadow: var(--shadow-md);
   z-index: 10;
 }
 
 .scroll-to-bottom-btn:hover {
-  box-shadow: 0 6px 16px rgba(0, 119, 204, 0.4);
+  box-shadow: var(--shadow-md);
 }
 
 .message-badge {
@@ -348,7 +351,7 @@
   top: -6px;
   right: -6px;
   background: var(--danger-color);
-  color: white;
+  color: var(--button-text);
   font-size: 0.7rem;
   font-weight: 600;
   border-radius: 50%;
@@ -357,7 +360,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 2px solid white;
+  border: 2px solid var(--card-background);
 }
 
 @keyframes fadeInUp {
@@ -376,7 +379,6 @@
   align-items: center;
   padding: var(--spacing-md);
   border-top: 1px solid var(--border-color);
-  background-color: white;
   position: relative;
   z-index: 3;
 }
@@ -384,7 +386,9 @@
 .message-input {
   flex: 1;
   padding: var(--spacing-sm) var(--spacing-md);
-  border: 1px solid var(--border-color);
+  border: 1px solid var(--input-border);
+  background-color: var(--input-background);
+  color: var(--text-color);
   border-radius: 20px;
   margin-right: var(--spacing-sm);
   resize: none;
@@ -398,7 +402,7 @@
 .message-input:disabled {
   opacity: 0.6;
   cursor: not-allowed;
-  background-color: #f5f5f5;
+  background-color: var(--border-color);
 }
 
 .custom-send-icon {
@@ -424,7 +428,7 @@
   align-items: center;
   justify-content: center;
   background-color: var(--primary-color);
-  color: white;
+  color: var(--button-text);
   border: none;
   cursor: pointer;
   min-height: 44px;
@@ -433,7 +437,7 @@
 }
 
 .send-button:disabled {
-  background-color: #ccc;
+  background-color: var(--text-secondary);
   cursor: not-allowed;
   opacity: 0.6;
 }
@@ -445,8 +449,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: #f1f1f1;
-  color: #666;
+  background-color: var(--input-background);
+  color: var(--text-secondary);
   border: none;
   cursor: pointer;
   margin-left: 8px;
@@ -460,22 +464,22 @@
   align-items: center;
   justify-content: center;
   padding: var(--spacing-xl);
-  color: #888;
+  color: var(--text-secondary);
   text-align: center;
 }
 
 .empty-chat mat-icon {
   font-size: 48px;
   margin-bottom: var(--spacing-md);
-  color: #ccc;
+  color: var(--text-secondary);
 }
 
 .key-loading,
 .key-missing {
   text-align: center;
   padding: var(--spacing-md);
-  background-color: #f8f9fa;
-  color: #666;
+  background-color: var(--card-background);
+  color: var(--text-secondary);
   font-style: italic;
 }
 
@@ -578,10 +582,8 @@
     top: var(--header-height);
     left: 0;
     right: 0;
-    background-color: #f8f9fa;
     border-bottom: 1px solid var(--border-color);
     z-index: 90;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
     height: 60px;
     display: flex;
     align-items: center;
@@ -611,11 +613,9 @@
     bottom: 0;
     left: 0;
     right: 0;
-    background-color: white;
     border-top: 1px solid var(--border-color);
     z-index: 1000;
     padding-bottom: calc(var(--spacing-sm) + env(safe-area-inset-bottom));
-    box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.1);
     min-height: 70px;
     max-height: 200px;
     box-sizing: border-box;
@@ -653,7 +653,7 @@
     left: 0;
     right: 0;
     bottom: calc(70px + env(safe-area-inset-bottom, 0px));
-    background: rgba(255, 255, 255, 0.95);
+    background: var(--card-background);
     backdrop-filter: blur(10px);
     -webkit-backdrop-filter: blur(10px);
     padding: var(--spacing-xs) var(--spacing-md);
@@ -662,11 +662,11 @@
     border-bottom: 1px solid var(--border-color);
     border-radius: 0;
     font-style: italic;
-    color: #666;
+    color: var(--text-secondary);
     font-size: 0.8rem;
     text-align: left;
     z-index: 1001;
-    box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.1);
+    box-shadow: var(--shadow-sm);
     animation: fadeInUp 0.3s ease-out;
   }
 

--- a/frontend/src/app/features/chat/chat-room/chat-room.component.css
+++ b/frontend/src/app/features/chat/chat-room/chat-room.component.css
@@ -4,12 +4,19 @@
   margin: 0 auto;
   padding: 0 var(--spacing-xl);
   box-sizing: border-box;
+  position: fixed;
+  top: var(--header-height);
+  left: 50%;
+  transform: translateX(-50%);
+  height: calc(100vh - var(--header-height) - var(--footer-height) - 50px);
+  display: flex;
+  flex-direction: column;
 }
 
 .chat-container {
   display: flex;
   flex-direction: column;
-  height: calc(100vh - var(--header-height) - var(--footer-height) - 32px);
+  flex: 1;
   width: 100%;
   overflow: hidden;
   z-index: 1;
@@ -17,16 +24,23 @@
   border-radius: var(--border-radius);
   box-shadow: var(--shadow-sm);
   background-color: var(--card-background);
+  position: relative;
 }
 
 .chat-header {
   display: flex;
   align-items: center;
   padding: var(--spacing-md) 0;
-  border-bottom: 1px solid var(--border-color);
   justify-content: space-between;
   background: transparent;
-  margin-bottom: var(--spacing-md);
+  flex-shrink: 0;
+}
+
+/* Large screen spacing */
+@media (min-width: 1200px) {
+  .chat-header {
+    padding: var(--spacing-lg) 0;
+  }
 }
 
 /* Left side: back button + user info */
@@ -324,8 +338,8 @@
 }
 
 .scroll-to-bottom-btn {
-  position: fixed;
-  bottom: calc(var(--footer-height) + 32px + 90px);
+  position: absolute;
+  bottom: calc(80px + 40px); /* form height + 40px above form */
   left: 50%;
   transform: translateX(-50%);
   width: 48px;
@@ -338,12 +352,11 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: var(--shadow-md);
   z-index: 10;
 }
 
 .scroll-to-bottom-btn:hover {
-  box-shadow: var(--shadow-md);
+  transform: translateX(-50%) scale(1.05);
 }
 
 .message-badge {
@@ -381,6 +394,7 @@
   border-top: 1px solid var(--border-color);
   position: relative;
   z-index: 3;
+  flex-shrink: 0;
 }
 
 .message-input {
@@ -487,7 +501,7 @@
   color: var(--warning-color);
 }
 
-/* Styling for unreadable messages */
+/* Styling for unreadable messages - Light theme */
 .message.unreadable {
   opacity: 0.85;
   background-color: #f8f9fa !important;
@@ -502,11 +516,45 @@
   background-color: #e3f2fd !important;
 }
 
+/* Dark theme styling for unreadable messages */
+.dark-theme .message.unreadable {
+  background-color: rgba(255, 255, 255, 0.05) !important;
+  opacity: 0.7;
+}
+
+.dark-theme .message.unreadable .message-content {
+  color: var(--text-secondary) !important;
+}
+
+.dark-theme .message.you.unreadable {
+  background-color: rgba(195, 247, 58, 0.1) !important;
+}
+
+/* Fix message time and status visibility for unreadable messages */
+/* Light theme - make time/status darker on light blue background */
+.message.you.unreadable .message-time,
+.message.you.unreadable .message-status {
+  color: #0277bd !important;
+  opacity: 0.8 !important;
+}
+
+/* Dark theme - make time/status lighter on light green background */
+.dark-theme .message.you.unreadable .message-time,
+.dark-theme .message.you.unreadable .message-status {
+  color: rgba(195, 247, 58, 0.9) !important;
+  opacity: 1 !important;
+}
+
 /* Indicator text styling */
 .unreadable-indicator {
   color: #6c757d;
   font-size: 0.7rem;
   font-weight: normal;
+}
+
+/* Dark theme indicator */
+.dark-theme .unreadable-indicator {
+  color: var(--text-secondary) !important;
 }
 
 /* Unreadable message actions area */
@@ -522,6 +570,12 @@
   padding: 2px 6px;
   border-radius: 8px;
   box-shadow: var(--shadow-sm);
+}
+
+/* Dark theme unreadable actions */
+.dark-theme .unreadable-actions {
+  color: var(--text-secondary) !important;
+  background-color: rgba(0, 0, 0, 0.6) !important;
 }
 
 .unreadable-actions .info-icon {
@@ -560,14 +614,20 @@
 
 /* Mobile adjustments */
 @media (max-width: 599px) {
-  /* Remove all padding for full-width chat */
+  /* Reset mobile wrapper to normal positioning */
   .chat-wrapper {
     padding: 0;
     margin: 0;
+    position: static;
+    top: auto;
+    left: auto;
+    transform: none;
+    height: auto;
+    display: block;
   }
 
   .chat-container {
-    height: 100vh;
+    height: calc(100vh - var(--header-height));
     border-radius: 0;
     box-shadow: none;
     margin: 0;
@@ -582,28 +642,28 @@
     top: var(--header-height);
     left: 0;
     right: 0;
-    border-bottom: 1px solid var(--border-color);
+    background-color: #f8f9fa !important;
     z-index: 90;
     height: 60px;
     display: flex;
     align-items: center;
   }
 
+  /* Dark theme mobile chat-header */
+  .dark-theme .chat-header {
+    background-color: #001011 !important;
+  }
+
   .chat-container app-cache-info-banner {
-    position: fixed !important;
-    top: calc(var(--header-height) + 60px);
-    left: 0;
-    right: 0;
-    z-index: 85;
+    /* Let the banner component handle its own positioning */
   }
 
   .chat-window {
     padding: var(--spacing-sm) var(--spacing-md);
-    padding-top: 70px;
-    padding-bottom: 90px;
-    height: 100vh;
+    /* Calculate proper height: viewport - app header - chat header (60px) - chat form (80px) */
+    height: calc(100vh - var(--header-height) - 60px - 80px);
     overflow-y: auto;
-    margin-top: var(--header-height);
+    margin-top: calc(var(--header-height) + 60px);
     position: relative;
   }
 
@@ -613,10 +673,11 @@
     bottom: 0;
     left: 0;
     right: 0;
+    background-color: var(--card-background);
     border-top: 1px solid var(--border-color);
     z-index: 1000;
     padding-bottom: calc(var(--spacing-sm) + env(safe-area-inset-bottom));
-    min-height: 70px;
+    min-height: 80px;
     max-height: 200px;
     box-sizing: border-box;
   }
@@ -686,7 +747,7 @@
 
   .scroll-to-bottom-btn {
     position: fixed;
-    bottom: 100px;
+    bottom: 120px; /* Above the fixed chat-form */
     left: 50%;
     width: 44px;
     height: 44px;

--- a/frontend/src/app/features/chat/chat-room/chat-room.component.css
+++ b/frontend/src/app/features/chat/chat-room/chat-room.component.css
@@ -663,7 +663,6 @@
     /* Calculate proper height: viewport - app header - chat header (60px) - chat form (80px) */
     height: calc(100vh - var(--header-height) - 60px - 80px);
     overflow-y: auto;
-    margin-top: calc(var(--header-height) + 60px);
     position: relative;
   }
 

--- a/frontend/src/app/features/chat/chat-room/chat-room.component.html
+++ b/frontend/src/app/features/chat/chat-room/chat-room.component.html
@@ -1,45 +1,46 @@
 <div class="chat-wrapper">
-  <div class="chat-container">
-    <div class="chat-header">
-      <div class="left-side">
-        <button
-          mat-icon-button
-          class="back-button"
-          (click)="navigateToList($event)"
-        >
-          <mat-icon>arrow_back</mat-icon>
-        </button>
+  <div class="chat-header">
+    <div class="left-side">
+      <button
+        mat-icon-button
+        class="back-button"
+        (click)="navigateToList($event)"
+      >
+        <mat-icon>arrow_back</mat-icon>
+      </button>
 
-        <div class="user-info">
-          <img
-            [src]="getPartnerAvatar()"
-            [alt]="(chat.theirUsername$ | async) || 'User'"
-            class="avatar"
-          />
-          <div>
-            <h3 class="username">
-              {{ (chat.theirUsername$ | async) || 'User' }}
-            </h3>
-          </div>
-        </div>
-      </div>
-
-      <!-- Right side: status -->
-      <div class="right-side">
-        <div class="status">
-          <span
-            class="status-dot"
-            [class.online]="isPartnerOnline"
-            [class.offline]="!isPartnerOnline"
-          ></span>
-          <span>{{
-            isPartnerOnline
-              ? ((chat.theirUsername$ | async) || 'User') + ' is online'
-              : ((chat.theirUsername$ | async) || 'User') + ' is offline'
-          }}</span>
+      <div class="user-info">
+        <img
+          [src]="getPartnerAvatar()"
+          [alt]="(chat.theirUsername$ | async) || 'User'"
+          class="avatar"
+        />
+        <div>
+          <h3 class="username">
+            {{ (chat.theirUsername$ | async) || 'User' }}
+          </h3>
         </div>
       </div>
     </div>
+
+    <!-- Right side: status -->
+    <div class="right-side">
+      <div class="status">
+        <span
+          class="status-dot"
+          [class.online]="isPartnerOnline"
+          [class.offline]="!isPartnerOnline"
+        ></span>
+        <span>{{
+          isPartnerOnline
+            ? ((chat.theirUsername$ | async) || 'User') + ' is online'
+            : ((chat.theirUsername$ | async) || 'User') + ' is offline'
+        }}</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="chat-container">
 
     <app-cache-info-banner
       [showBanner]="showCacheInfoBanner"

--- a/frontend/src/app/features/chat/chat-room/chat-room.component.html
+++ b/frontend/src/app/features/chat/chat-room/chat-room.component.html
@@ -101,6 +101,7 @@
             [class.other]="m.sender !== 'You'"
             [class.deleted]="m.deletedAt"
             [class.unreadable]="isMessageUnreadable(m)"
+            [class.encrypted]="isMessageEncrypted(m)"
           >
             <div class="message-bubble">
               <p class="message-content">{{ m.text }}</p>

--- a/frontend/src/app/features/chat/chat-room/chat-room.component.ts
+++ b/frontend/src/app/features/chat/chat-room/chat-room.component.ts
@@ -921,6 +921,26 @@ export class ChatRoomComponent
   }
 
   /**
+   * Check if a message is encrypted (from partner)
+   * 
+   * NOTE: This uses text matching which can have false positives if users
+   * type the exact encrypted message text. For 100% accuracy, backend should
+   * provide explicit encryption status flags.
+   */
+  isMessageEncrypted(message: ChatMsg): boolean {
+    if (message.sender === 'You') return false;
+
+    // Check for exact encrypted message text
+    // Most users won't type this exact system message, so risk is minimal
+    const isEncryptedText = message.text === '🔒 Encrypted message (from partner)';
+    
+    return isEncryptedText;
+    
+    // TODO: Replace with proper backend flag when available:
+    // return message.decryptionFailed === true;
+  }
+
+  /**
    * Check if a message can be edited/deleted
    */
   canEditMessage(message: ChatMsg): boolean {

--- a/frontend/src/app/features/chat/chat-room/chat-room.component.ts
+++ b/frontend/src/app/features/chat/chat-room/chat-room.component.ts
@@ -10,6 +10,7 @@ import {
   Injectable,
   ChangeDetectorRef,
   NgZone,
+  ViewEncapsulation,
 } from '@angular/core';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
@@ -81,6 +82,7 @@ export class MyHammerConfig extends HammerGestureConfig {
   ],
   templateUrl: './chat-room.component.html',
   styleUrls: ['./chat-room.component.css'],
+  encapsulation: ViewEncapsulation.None
 })
 export class ChatRoomComponent
   implements OnInit, AfterViewChecked, AfterViewInit, OnDestroy

--- a/frontend/src/app/features/settings/settings.component.css
+++ b/frontend/src/app/features/settings/settings.component.css
@@ -177,12 +177,11 @@
 }
 
 .avatar-option img {
-  width: 100%;
-  height: 100%;
-  max-width: 100%;
-  max-height: 100%;
-  object-fit: contain;
-  border-radius: 4px;
+  width: 56px;
+  height: 56px;
+  object-fit: cover;
+  border-radius: 50%;
+  display: block;
 }
 
 .hint {

--- a/frontend/src/app/features/settings/settings.component.css
+++ b/frontend/src/app/features/settings/settings.component.css
@@ -9,9 +9,14 @@
 .settings-header {
   display: flex;
   align-items: center;
-  margin-bottom: var(--spacing-md);
   padding: var(--spacing-md) 0;
-  border-bottom: 1px solid var(--border-color);
+}
+
+/* Large screen spacing */
+@media (min-width: 1200px) {
+  .settings-header {
+    padding: var(--spacing-lg) 0;
+  }
 }
 
 .back-button {
@@ -203,7 +208,6 @@
 
 @media (max-width: 599px) {
   .settings-header {
-    margin-bottom: var(--spacing-md);
     padding: var(--spacing-sm) 0;
   }
 

--- a/frontend/src/app/features/settings/settings.component.css
+++ b/frontend/src/app/features/settings/settings.component.css
@@ -29,7 +29,7 @@
 }
 
 .back-button:hover {
-  background-color: rgba(0, 0, 0, 0.05);
+  background-color: var(--nav-hover);
 }
 
 .back-button mat-icon {
@@ -43,7 +43,7 @@
 }
 
 .settings-section {
-  background-color: white;
+  background-color: var(--card-background);
   border-radius: var(--border-radius);
   padding: var(--spacing-md);
   margin-bottom: var(--spacing-md);
@@ -59,7 +59,7 @@
 
 .settings-section p {
   margin-bottom: var(--spacing-md);
-  color: #666;
+  color: var(--text-secondary);
 }
 
 /* Custom Action Buttons */
@@ -99,7 +99,7 @@
 
 .download-button {
   background-color: var(--primary-color);
-  color: white;
+  color: var(--button-text);
 }
 
 .download-button:hover {
@@ -108,11 +108,11 @@
 
 .upload-button {
   background-color: var(--success-color);
-  color: white;
+  color: var(--button-text);
 }
 
 .upload-button:hover {
-  background-color: #5a9b72;
+  background-color: var(--success-hover, #5a9b72);
 }
 
 /* File Upload Container */
@@ -130,13 +130,13 @@
   font-size: 0.9rem;
   color: var(--text-color);
   padding: var(--spacing-xs) var(--spacing-sm);
-  background-color: #f8f9fa;
+  background-color: var(--input-background);
   border-radius: 4px;
   border: 1px solid var(--border-color);
 }
 
 .file-name.placeholder {
-  color: #999;
+  color: var(--text-secondary);
   font-style: italic;
 }
 
@@ -184,7 +184,7 @@
   display: block;
   margin-top: var(--spacing-sm);
   font-size: 0.8rem;
-  color: #666;
+  color: var(--text-secondary);
   font-family: 'Jost', sans-serif !important;
 }
 

--- a/frontend/src/app/shared/components/cache-info-banner/cache-info-banner.component.css
+++ b/frontend/src/app/shared/components/cache-info-banner/cache-info-banner.component.css
@@ -46,30 +46,42 @@
   color: rgba(195, 247, 58, 0.9) !important;
 }
 
-
 button {
   flex-shrink: 0;
 }
 
 @media (max-width: 599px) {
-  /* Light theme mobile */
+  /* Light theme mobile - Force solid background */
+  body .cache-info-banner,
+  html .cache-info-banner,
+  app-cache-info-banner .cache-info-banner,
+  div.cache-info-banner,
   .cache-info-banner {
-    font-size: 0.8rem;
-    padding: 10px;
-    margin: 0;
-    border-radius: 0;
-    border-left: none;
-    border-right: none;
-    position: sticky;
-    top: 0;
-    z-index: 100;
-    background-color: #e3f2fd;
-    box-shadow: var(--shadow-sm);
+    font-size: 0.8rem !important;
+    padding: 10px !important;
+    margin: 0 !important;
+    border-radius: 0 !important;
+    border: 1px solid #2196f3 !important;
+    border-left: none !important;
+    border-right: none !important;
+    position: fixed !important;
+    top: calc(var(--header-height) + 60px) !important;
+    left: 0 !important;
+    right: 0 !important;
+    z-index: 9999 !important;
+    background: #e3f2fd !important;
+    background-color: #e3f2fd !important;
+    background-image: none !important;
+    box-shadow: var(--shadow-sm) !important;
   }
-  
-  /* Dark theme mobile */
+
+  /* Dark theme mobile - Force solid background */
+  .dark-theme body .cache-info-banner,
+  .dark-theme html .cache-info-banner,
+  .dark-theme app-cache-info-banner .cache-info-banner,
+  .dark-theme div.cache-info-banner,
   .dark-theme .cache-info-banner {
-    background-color: rgba(195, 247, 58, 0.1) !important;
+    background-color: #213928 !important;
     border: 1px solid rgba(195, 247, 58, 0.3) !important;
     border-left: none !important;
     border-right: none !important;

--- a/frontend/src/app/shared/components/cache-info-banner/cache-info-banner.component.css
+++ b/frontend/src/app/shared/components/cache-info-banner/cache-info-banner.component.css
@@ -64,6 +64,7 @@ button {
     border: 1px solid #2196f3 !important;
     border-left: none !important;
     border-right: none !important;
+    border-bottom: none !important;
     position: fixed !important;
     top: calc(var(--header-height) + 60px) !important;
     left: 0 !important;
@@ -72,7 +73,6 @@ button {
     background: #e3f2fd !important;
     background-color: #e3f2fd !important;
     background-image: none !important;
-    box-shadow: var(--shadow-sm) !important;
   }
 
   /* Dark theme mobile - Force solid background */
@@ -82,7 +82,7 @@ button {
   .dark-theme div.cache-info-banner,
   .dark-theme .cache-info-banner {
     background-color: #213928 !important;
-    border: 1px solid rgba(195, 247, 58, 0.3) !important;
+    border-bottom: none !important;
     border-left: none !important;
     border-right: none !important;
     color: rgba(195, 247, 58, 0.9) !important;

--- a/frontend/src/app/shared/components/cache-info-banner/cache-info-banner.component.css
+++ b/frontend/src/app/shared/components/cache-info-banner/cache-info-banner.component.css
@@ -1,3 +1,4 @@
+/* Light theme styles */
 .cache-info-banner {
   display: flex;
   align-items: center;
@@ -6,6 +7,15 @@
   padding: 12px;
   gap: 12px;
   font-size: 0.75rem;
+  color: #0277bd;
+  border-radius: var(--border-radius) var(--border-radius) 0 0;
+}
+
+/* Dark theme styles */
+.dark-theme .cache-info-banner {
+  background-color: rgba(195, 247, 58, 0.1) !important;
+  border: 1px solid rgba(195, 247, 58, 0.3) !important;
+  color: rgba(195, 247, 58, 0.9) !important;
 }
 
 .banner-content {
@@ -25,16 +35,24 @@
   font-weight: 400;
 }
 
-mat-icon {
+/* Light theme icon */
+.cache-info-banner mat-icon {
   color: #2196f3;
   flex-shrink: 0;
 }
+
+/* Dark theme icon */
+.dark-theme .cache-info-banner mat-icon {
+  color: rgba(195, 247, 58, 0.9) !important;
+}
+
 
 button {
   flex-shrink: 0;
 }
 
 @media (max-width: 599px) {
+  /* Light theme mobile */
   .cache-info-banner {
     font-size: 0.8rem;
     padding: 10px;
@@ -46,7 +64,16 @@ button {
     top: 0;
     z-index: 100;
     background-color: #e3f2fd;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    box-shadow: var(--shadow-sm);
+  }
+  
+  /* Dark theme mobile */
+  .dark-theme .cache-info-banner {
+    background-color: rgba(195, 247, 58, 0.1) !important;
+    border: 1px solid rgba(195, 247, 58, 0.3) !important;
+    border-left: none !important;
+    border-right: none !important;
+    color: rgba(195, 247, 58, 0.9) !important;
   }
 }
 

--- a/frontend/src/app/shared/components/cache-info-banner/cache-info-banner.component.ts
+++ b/frontend/src/app/shared/components/cache-info-banner/cache-info-banner.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, ViewEncapsulation } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 import { MatIconModule } from '@angular/material/icon';
@@ -10,6 +10,7 @@ import { MatButtonModule } from '@angular/material/button';
   imports: [CommonModule, MatIconModule, MatButtonModule],
   templateUrl: '../cache-info-banner/cache-info-banner.component.html',
   styleUrl: '../cache-info-banner/cache-info-banner.component.css',
+  encapsulation: ViewEncapsulation.None
 })
 export class CacheInfoBannerComponent {
   @Input() showBanner = false;

--- a/frontend/src/app/shared/components/footer/footer.component.css
+++ b/frontend/src/app/shared/components/footer/footer.component.css
@@ -6,7 +6,7 @@
   width: 100%;
   height: var(--footer-height);
   backdrop-filter: blur(10px);
-  border-top: 1px solid rgba(0, 0, 0, 0.1);
+  border-top: 1px solid var(--border-color);
   z-index: 999;
   font-family: 'Jost', sans-serif;
 }
@@ -34,7 +34,7 @@
 
 /* Copyright text */
 .footer-copyright {
-  color: rgba(0, 0, 0, 0.9);
+  color: var(--text-color);
   font-size: 0.7rem;
   font-weight: 500;
   font-family: 'Jost', sans-serif;
@@ -44,7 +44,7 @@
 
 /* Disclaimer text */
 .footer-disclaimer {
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--text-secondary);
   font-size: 0.7rem;
   font-weight: 400;
   font-family: 'Jost', sans-serif;
@@ -69,7 +69,7 @@
   width: 40px;
   height: 40px;
   border-radius: 50%;
-  color: rgba(0, 0, 0, 0.7);
+  color: var(--text-secondary);
   text-decoration: none;
   position: relative;
   overflow: hidden;
@@ -97,7 +97,7 @@
 }
 
 .footer-social a:hover {
-  color: white;
+  color: var(--button-text);
   transform: translateY(-2px);
 }
 

--- a/frontend/src/app/shared/components/header/header.component.css
+++ b/frontend/src/app/shared/components/header/header.component.css
@@ -89,6 +89,9 @@
 .dark-theme .theme-toggle:focus,
 .dark-theme .theme-toggle:focus-visible,
 .dark-theme .theme-toggle:active,
+.dark-theme .theme-toggle-btn:focus,
+.dark-theme .theme-toggle-btn:focus-visible,
+.dark-theme .theme-toggle-btn:active,
 .dark-theme .mobile-menu-button:focus,
 .dark-theme .mobile-menu-button:focus-visible,
 .dark-theme .mobile-menu-button:active,
@@ -138,7 +141,7 @@
 .mobile-controls {
   display: none;
   align-items: center;
-  gap: var(--spacing-sm);
+  gap: var(--spacing-md);
 }
 
 .desktop-status {
@@ -147,8 +150,8 @@
 
 .mobile-status {
   display: none;
-  padding: 4px;
-  margin: 0;
+  padding: 2px 6px;
+  margin: 0 8px;
   background-color: transparent;
   border: none;
 }
@@ -256,6 +259,14 @@
     display: none;
   }
 
+  .desktop-theme-toggle {
+    display: none !important;
+  }
+
+  .nav-links.open .desktop-theme-toggle {
+    display: none !important;
+  }
+
   .nav-links {
     display: none;
   }
@@ -354,7 +365,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: none;
+    background: transparent;
     border: none;
     padding: var(--spacing-sm);
     cursor: pointer;
@@ -362,17 +373,24 @@
     min-width: 44px;
     border-radius: 12px;
     transition: all 0.2s ease;
-    color: var(--primary-color);
+    color: var(--text-color);
     position: relative;
   }
 
   .mobile-menu-button:hover {
-    background-color: var(--nav-hover);
+    color: var(--primary-color);
     transform: scale(1.05);
   }
 
   .mobile-menu-button:active {
     transform: scale(0.95);
+  }
+
+  /* Prevent mobile menu button from staying active/focused */
+  .mobile-menu-button:focus,
+  .mobile-menu-button:focus-visible {
+    outline: none !important;
+    background-color: transparent !important;
   }
 
   .mobile-menu-badge {
@@ -416,8 +434,9 @@
   }
 }
 
-/* Theme toggle button */
-.theme-toggle {
+
+/* Mobile theme toggle (in mobile-controls) - separate styling */
+.mobile-controls .theme-toggle {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -433,24 +452,30 @@
   position: relative;
 }
 
-.theme-toggle:hover {
+.mobile-controls .theme-toggle:hover {
   background: transparent !important;
   transform: scale(1.05);
 }
 
-.theme-toggle:active {
+.mobile-controls .theme-toggle:active {
   transform: scale(0.95);
 }
 
-.theme-toggle mat-icon {
+.mobile-controls .theme-toggle:focus,
+.mobile-controls .theme-toggle.active {
+  background: transparent !important;
+  transform: scale(1.05) !important;
+}
+
+.mobile-controls .theme-toggle mat-icon {
   font-size: 20px;
   width: 20px;
   height: 20px;
   transition: transform 0.3s ease;
 }
 
-/* Theme toggle animation */
-.theme-toggle:hover mat-icon {
+/* Theme toggle animation for mobile */
+.mobile-controls .theme-toggle:hover mat-icon {
   transform: rotate(15deg);
 }
 

--- a/frontend/src/app/shared/components/header/header.component.css
+++ b/frontend/src/app/shared/components/header/header.component.css
@@ -4,13 +4,13 @@
   left: 0;
   width: 100%;
   height: var(--header-height);
-  background-color: rgba(255, 255, 255, 0.95);
+  background-color: var(--header-background);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.04);
+  box-shadow: var(--shadow-sm);
   z-index: 100;
   transition: all 0.3s ease;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .header-container {
@@ -79,6 +79,15 @@
 .nav-links button:hover {
   color: var(--primary-color);
   transform: translateY(-1px);
+  background: transparent !important;
+}
+
+/* Remove focus states in dark theme for header buttons */
+.dark-theme .nav-links button:focus,
+.dark-theme .theme-toggle:focus,
+.dark-theme .mobile-menu-button:focus {
+  outline: none !important;
+  box-shadow: none !important;
 }
 
 .nav-links button:active {
@@ -234,7 +243,7 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background-color: white;
+    background-color: var(--background-color);
     display: flex;
     flex-direction: column;
     padding: var(--spacing-lg);
@@ -257,8 +266,8 @@
     justify-content: flex-start;
     padding: var(--spacing-md);
     border: none;
-    background-color: white;
-    border: 1px solid #e0e0e0;
+    background-color: var(--card-background);
+    border: 1px solid var(--border-color);
     border-radius: var(--border-radius);
     font-size: 1rem;
     font-weight: 500;
@@ -268,14 +277,41 @@
     min-height: 56px;
     width: 100%;
     color: var(--text-color);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    box-shadow: var(--shadow-sm);
   }
 
   .nav-links.open button:hover {
-    background-color: #f8f9fa;
+    background-color: var(--nav-hover);
     border-color: var(--primary-color);
     transform: translateY(-1px);
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+    box-shadow: var(--shadow-md);
+  }
+
+  /* Fix mobile menu button borders in dark theme - remove double borders */
+  .dark-theme .nav-links.open button {
+    border: 1px solid var(--border-color) !important;
+  }
+
+  .dark-theme .nav-links.open button:hover {
+    background-color: var(--nav-hover) !important;
+    border-color: var(--primary-color) !important;
+  }
+
+  /* Remove focus states for mobile menu buttons in dark theme */
+  .dark-theme .nav-links.open button:focus {
+    outline: none !important;
+    box-shadow: var(--shadow-sm) !important;
+  }
+
+  /* Active page highlighting in mobile menu */
+  .nav-links.open button.active {
+    background-color: var(--nav-hover) !important;
+    border-color: var(--primary-color) !important;
+    color: var(--primary-color) !important;
+  }
+
+  .nav-links.open button.active mat-icon {
+    color: var(--primary-color) !important;
   }
 
   .nav-links.open button:active {
@@ -308,7 +344,7 @@
   }
 
   .mobile-menu-button:hover {
-    background-color: rgba(0, 119, 204, 0.08);
+    background-color: var(--nav-hover);
     transform: scale(1.05);
   }
 
@@ -355,6 +391,44 @@
       opacity: 1;
     }
   }
+}
+
+/* Theme toggle button */
+.theme-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: var(--spacing-sm);
+  cursor: pointer;
+  min-height: 40px;
+  min-width: 40px;
+  border-radius: 12px;
+  transition: all 0.2s ease;
+  color: var(--text-color);
+  position: relative;
+}
+
+.theme-toggle:hover {
+  background: transparent !important;
+  transform: scale(1.05);
+}
+
+.theme-toggle:active {
+  transform: scale(0.95);
+}
+
+.theme-toggle mat-icon {
+  font-size: 20px;
+  width: 20px;
+  height: 20px;
+  transition: transform 0.3s ease;
+}
+
+/* Theme toggle animation */
+.theme-toggle:hover mat-icon {
+  transform: rotate(15deg);
 }
 
 /* Fade-in animation for mobile menu */

--- a/frontend/src/app/shared/components/header/header.component.css
+++ b/frontend/src/app/shared/components/header/header.component.css
@@ -244,6 +244,14 @@
   .header-container {
     padding: 0 var(--spacing-md);
   }
+
+  .nav-links {
+    gap: var(--spacing-sm);
+  }
+
+  .nav-links button {
+    font-size: 0.75rem;
+  }
 }
 
 @media (max-width: 599px) {
@@ -433,7 +441,6 @@
     }
   }
 }
-
 
 /* Mobile theme toggle (in mobile-controls) - separate styling */
 .mobile-controls .theme-toggle {

--- a/frontend/src/app/shared/components/header/header.component.css
+++ b/frontend/src/app/shared/components/header/header.component.css
@@ -82,12 +82,35 @@
   background: transparent !important;
 }
 
-/* Remove focus states in dark theme for header buttons */
+/* Remove focus and active states in dark theme for header buttons */
 .dark-theme .nav-links button:focus,
+.dark-theme .nav-links button:focus-visible,
+.dark-theme .nav-links button:active,
 .dark-theme .theme-toggle:focus,
-.dark-theme .mobile-menu-button:focus {
+.dark-theme .theme-toggle:focus-visible,
+.dark-theme .theme-toggle:active,
+.dark-theme .mobile-menu-button:focus,
+.dark-theme .mobile-menu-button:focus-visible,
+.dark-theme .mobile-menu-button:active,
+.dark-theme .header button:focus,
+.dark-theme .header button:focus-visible,
+.dark-theme .header button:active,
+.dark-theme .header .mat-mdc-button:focus,
+.dark-theme .header .mat-mdc-button:focus-visible,
+.dark-theme .header .mat-mdc-button:active,
+.dark-theme .header .mat-mdc-icon-button:focus,
+.dark-theme .header .mat-mdc-icon-button:focus-visible,
+.dark-theme .header .mat-mdc-icon-button:active {
   outline: none !important;
   box-shadow: none !important;
+  border: none !important;
+  background: transparent !important;
+}
+
+/* Remove Material Design ripple effects in dark theme header */
+.dark-theme .header .mat-mdc-button .mdc-button__ripple,
+.dark-theme .header .mat-mdc-icon-button .mdc-icon-button__ripple {
+  display: none !important;
 }
 
 .nav-links button:active {

--- a/frontend/src/app/shared/components/header/header.component.html
+++ b/frontend/src/app/shared/components/header/header.component.html
@@ -1,20 +1,30 @@
 <header class="header">
   <div class="header-container">
-    <a routerLink="/" class="logo">
+    <a href="/" class="logo">
       <img
         src="assets/images/logo.svg"
         alt="Quasar Contact Logo Icon"
         class="logo-icon retina-image"
       />
       <img
-        [src]="isDarkTheme() ? 'assets/images/text-logo-white.svg' : 'assets/images/text-logo-dark.svg'"
+        [src]="
+          isDarkTheme()
+            ? 'assets/images/text-logo-white.svg'
+            : 'assets/images/text-logo-dark.svg'
+        "
         alt="Quasar Contact Logo Text"
         class="logo-text retina-image"
       />
     </a>
 
     <!-- Mobile controls - status + theme toggle + hamburger button with notification badge -->
-    <div class="mobile-controls" *ngIf="authService.isAuthenticated() || (!authService.isAuthenticated() && isAuthPage())">
+    <div
+      class="mobile-controls"
+      *ngIf="
+        authService.isAuthenticated() ||
+        (!authService.isAuthenticated() && isAuthPage())
+      "
+    >
       <!-- Connection status with text on mobile -->
       <div
         *ngIf="authService.isAuthenticated()"
@@ -27,10 +37,12 @@
       </div>
 
       <!-- Theme toggle - always visible -->
-      <button 
-        class="theme-toggle" 
-        (click)="toggleTheme()" 
-        [title]="isDarkTheme() ? 'Switch to light theme' : 'Switch to dark theme'"
+      <button
+        class="theme-toggle"
+        (click)="toggleTheme()"
+        [title]="
+          isDarkTheme() ? 'Switch to light theme' : 'Switch to dark theme'
+        "
         aria-label="Toggle theme"
       >
         <mat-icon>{{ isDarkTheme() ? 'light_mode' : 'dark_mode' }}</mat-icon>
@@ -57,7 +69,7 @@
           <mat-icon>person_add</mat-icon>
           <span class="mobile-hidden">Create Account</span>
         </button>
-        
+
         <button
           *ngIf="router.url !== '/auth/login'"
           mat-button
@@ -80,29 +92,7 @@
         <span>{{ online ? `Online` : `Offline` }}</span>
       </div>
 
-      <!-- Theme toggle button (desktop only) -->
-      <button 
-        class="desktop-theme-toggle"
-        (click)="toggleTheme()"
-        [title]="isDarkTheme() ? 'Switch to light theme' : 'Switch to dark theme'"
-        aria-label="Toggle theme"
-        mat-button>
-        <mat-icon>{{ isDarkTheme() ? 'light_mode' : 'dark_mode' }}</mat-icon>
-        <span class="mobile-hidden">{{ isDarkTheme() ? 'Light' : 'Dark' }}</span>
-      </button>
-
-      <!-- settings (only when authenticated) -->
-      <button
-        *ngIf="authService.isAuthenticated()"
-        mat-button
-        title="Settings"
-        (click)="navigateToSettings()"
-        [class.active]="router.url.startsWith('/settings')"
-      >
-        <mat-icon>settings</mat-icon>
-        <span class="mobile-hidden">Settings</span>
-      </button>
-
+      <!-- Chats (only when authenticated) -->
       <button
         *ngIf="authService.isAuthenticated()"
         mat-button
@@ -114,7 +104,35 @@
         <span *ngIf="unreadTotal" class="badge">{{ unreadTotal }}</span>
       </button>
 
-      <!-- existing logout -->
+      <!-- Settings (only when authenticated) -->
+      <button
+        *ngIf="authService.isAuthenticated()"
+        mat-button
+        title="Settings"
+        (click)="navigateToSettings()"
+        [class.active]="router.url.startsWith('/settings')"
+      >
+        <mat-icon>settings</mat-icon>
+        <span class="mobile-hidden">Settings</span>
+      </button>
+
+      <!-- Theme toggle button (desktop only) -->
+      <button
+        class="desktop-theme-toggle"
+        (click)="toggleTheme()"
+        [title]="
+          isDarkTheme() ? 'Switch to light theme' : 'Switch to dark theme'
+        "
+        aria-label="Toggle theme"
+        mat-button
+      >
+        <mat-icon>{{ isDarkTheme() ? 'light_mode' : 'dark_mode' }}</mat-icon>
+        <span class="mobile-hidden">{{
+          isDarkTheme() ? 'Light' : 'Dark'
+        }}</span>
+      </button>
+
+      <!-- Logout -->
       <button *ngIf="showLogout" mat-button (click)="logout()">
         <mat-icon>exit_to_app</mat-icon>
         <span class="mobile-hidden">Logout</span>

--- a/frontend/src/app/shared/components/header/header.component.html
+++ b/frontend/src/app/shared/components/header/header.component.html
@@ -7,7 +7,7 @@
         class="logo-icon retina-image"
       />
       <img
-        src="assets/images/text-logo-dark.svg"
+        [src]="isDarkTheme() ? 'assets/images/text-logo-white.svg' : 'assets/images/text-logo-dark.svg'"
         alt="Quasar Contact Logo Text"
         class="logo-text retina-image"
       />
@@ -58,6 +58,16 @@
         </button>
       </ng-container>
 
+      <!-- Theme toggle button -->
+      <button 
+        class="theme-toggle" 
+        (click)="toggleTheme()" 
+        [title]="isDarkTheme() ? 'Switch to light theme' : 'Switch to dark theme'"
+        aria-label="Toggle theme"
+      >
+        <mat-icon>{{ isDarkTheme() ? 'light_mode' : 'dark_mode' }}</mat-icon>
+      </button>
+
       <!-- Desktop connection status (hidden on mobile) -->
       <div
         *ngIf="authService.isAuthenticated()"
@@ -75,6 +85,7 @@
         mat-button
         title="Settings"
         (click)="navigateToSettings()"
+        [class.active]="router.url.startsWith('/settings')"
       >
         <mat-icon>settings</mat-icon>
         <span class="mobile-hidden">Settings</span>
@@ -84,6 +95,7 @@
         *ngIf="authService.isAuthenticated()"
         mat-button
         (click)="navigateToChats()"
+        [class.active]="router.url.startsWith('/chat')"
       >
         <mat-icon>chat</mat-icon>
         <span class="mobile-hidden">Chats</span>

--- a/frontend/src/app/shared/components/header/header.component.html
+++ b/frontend/src/app/shared/components/header/header.component.html
@@ -13,9 +13,9 @@
       />
     </a>
 
-    <!-- Mobile controls - status + hamburger button with notification badge -->
+    <!-- Mobile controls - status + theme toggle + hamburger button with notification badge -->
     <div class="mobile-controls" *ngIf="authService.isAuthenticated() || (!authService.isAuthenticated() && isAuthPage())">
-      <!-- Connection status near hamburger button on mobile -->
+      <!-- Connection status with text on mobile -->
       <div
         *ngIf="authService.isAuthenticated()"
         class="status mobile-status"
@@ -23,7 +23,18 @@
         [class.disconnected]="!online"
       >
         <span class="status-dot"></span>
+        <span>{{ online ? 'Online' : 'Offline' }}</span>
       </div>
+
+      <!-- Theme toggle - always visible -->
+      <button 
+        class="theme-toggle" 
+        (click)="toggleTheme()" 
+        [title]="isDarkTheme() ? 'Switch to light theme' : 'Switch to dark theme'"
+        aria-label="Toggle theme"
+      >
+        <mat-icon>{{ isDarkTheme() ? 'light_mode' : 'dark_mode' }}</mat-icon>
+      </button>
 
       <button class="mobile-menu-button" (click)="toggleMenu()">
         <mat-icon>{{ menuOpen ? 'close' : 'menu' }}</mat-icon>
@@ -58,16 +69,6 @@
         </button>
       </ng-container>
 
-      <!-- Theme toggle button -->
-      <button 
-        class="theme-toggle" 
-        (click)="toggleTheme()" 
-        [title]="isDarkTheme() ? 'Switch to light theme' : 'Switch to dark theme'"
-        aria-label="Toggle theme"
-      >
-        <mat-icon>{{ isDarkTheme() ? 'light_mode' : 'dark_mode' }}</mat-icon>
-      </button>
-
       <!-- Desktop connection status (hidden on mobile) -->
       <div
         *ngIf="authService.isAuthenticated()"
@@ -78,6 +79,17 @@
         <span class="status-dot"></span>
         <span>{{ online ? `Online` : `Offline` }}</span>
       </div>
+
+      <!-- Theme toggle button (desktop only) -->
+      <button 
+        class="desktop-theme-toggle"
+        (click)="toggleTheme()"
+        [title]="isDarkTheme() ? 'Switch to light theme' : 'Switch to dark theme'"
+        aria-label="Toggle theme"
+        mat-button>
+        <mat-icon>{{ isDarkTheme() ? 'light_mode' : 'dark_mode' }}</mat-icon>
+        <span class="mobile-hidden">{{ isDarkTheme() ? 'Light' : 'Dark' }}</span>
+      </button>
 
       <!-- settings (only when authenticated) -->
       <button

--- a/frontend/src/app/shared/components/header/header.component.ts
+++ b/frontend/src/app/shared/components/header/header.component.ts
@@ -15,6 +15,7 @@ import { WebSocketService } from '@services/websocket.service';
 import { LoadingService } from '@services/loading.service';
 import { AuthService } from '@services/auth.service';
 import { NotificationService } from '@services/notification.service';
+import { ThemeService } from '@services/theme.service';
 
 @Component({
   selector: 'app-header',
@@ -41,7 +42,8 @@ export class HeaderComponent implements OnInit, OnDestroy {
     private loadingService: LoadingService,
     private cdr: ChangeDetectorRef,
     private ngZone: NgZone,
-    private notificationService: NotificationService
+    private notificationService: NotificationService,
+    private themeService: ThemeService
   ) {
     // Keep the header status in sync with WebSocket connection
     this.sub = this.wsService.isConnected$.subscribe((status) => {
@@ -166,6 +168,16 @@ export class HeaderComponent implements OnInit, OnDestroy {
   // Check if user is currently on an auth page
   isAuthPage(): boolean {
     return this.router.url.startsWith('/auth');
+  }
+
+  // Theme toggle methods
+  toggleTheme(): void {
+    console.log('[Header] Theme toggle clicked');
+    this.themeService.toggleTheme();
+  }
+
+  isDarkTheme(): boolean {
+    return this.themeService.isDarkTheme();
   }
 
   ngOnDestroy(): void {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -635,13 +635,14 @@ select:focus {
   background-color: var(--nav-hover) !important;
 }
 
-/* Override Material Design focus outline */
+/* Remove Material Design focus outline in dark theme */
 .dark-theme .mat-mdc-button:focus,
 .dark-theme .mat-mdc-raised-button:focus,
 .dark-theme .mat-mdc-outlined-button:focus,
-.dark-theme .mat-mdc-unelevated-button:focus {
-  outline: 2px solid var(--primary-color) !important;
-  outline-offset: 2px !important;
+.dark-theme .mat-mdc-unelevated-button:focus,
+.dark-theme .mat-mdc-icon-button:focus {
+  outline: none !important;
+  outline-offset: 0 !important;
 }
 
 /* Chat and content backgrounds */

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -311,7 +311,7 @@ input[ng-reflect] {
   --input-border: #3c4f4f;
   --button-background: var(--primary-color);
   --button-text: #001011;
-  --header-background: rgba(12, 37, 36, 0.5);
+  --header-background: rgb(12, 37, 36, 0.5);
   --nav-hover: rgba(195, 247, 58, 0.1);
   --warning-background: rgba(255, 183, 77, 0.1);
   --warning-text: #ffb74d;
@@ -685,6 +685,85 @@ select:focus {
   background-color: var(--card-background) !important;
   color: var(--text-color) !important;
   border-color: var(--border-color) !important;
+}
+
+/* Global avatar borders - inner borders using outline */
+.avatar,
+img.avatar,
+.chat-wrapper .avatar,
+.chat-wrapper img.avatar,
+.user-info .avatar,
+.user-info img.avatar,
+.chat-wrapper .chat-header .left-side .user-info img.avatar,
+.chat-header .user-info img.avatar {
+  outline: 1px solid #fff !important;
+  outline-offset: -1px !important;
+  border-radius: 50% !important;
+}
+
+/* Settings avatars - special handling for better cross-browser compatibility */
+.avatar-option {
+  position: relative !important;
+}
+
+.avatar-option::after {
+  content: '' !important;
+  position: absolute !important;
+  top: 50% !important;
+  left: 50% !important;
+  width: 54px !important;
+  height: 54px !important;
+  transform: translate(-50%, -50%) !important;
+  border: 1px solid #fff !important;
+  border-radius: 50% !important;
+  pointer-events: none !important;
+  z-index: 1 !important;
+}
+
+.avatar-option::before {
+  content: '' !important;
+  position: absolute !important;
+  top: 50% !important;
+  left: 50% !important;
+  width: 54px !important;
+  height: 54px !important;
+  transform: translate(-50%, -50%) !important;
+  border: 1px solid #fff !important;
+  border-radius: 50% !important;
+  pointer-events: none !important;
+  z-index: 1 !important;
+}
+
+/* Dark theme avatar borders - inner borders */
+body.dark-theme .avatar,
+body.dark-theme img.avatar,
+body.dark-theme .chat-wrapper .avatar,
+body.dark-theme .chat-wrapper img.avatar,
+body.dark-theme .user-info .avatar,
+body.dark-theme .user-info img.avatar,
+body.dark-theme .chat-wrapper .chat-header .left-side .user-info img.avatar,
+body.dark-theme .chat-header .user-info img.avatar,
+.dark-theme .avatar,
+.dark-theme img.avatar,
+.dark-theme .chat-wrapper .avatar,
+.dark-theme .chat-wrapper img.avatar,
+.dark-theme .user-info .avatar,
+.dark-theme .user-info img.avatar,
+.dark-theme .chat-wrapper .chat-header .left-side .user-info img.avatar,
+.dark-theme .chat-header .user-info img.avatar {
+  outline: 1px solid #001011 !important;
+  outline-offset: -1px !important;
+}
+
+/* Dark theme settings avatars */
+body.dark-theme .avatar-option::after,
+.dark-theme .avatar-option::after {
+  border: 1px solid #001011 !important;
+}
+
+body.dark-theme .avatar-option::before,
+.dark-theme .avatar-option::before {
+  border: 1px solid #001011 !important;
 }
 
 .chat-container {

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -622,9 +622,15 @@ select:focus {
 
 /* Override Material Design button hover effects for dark theme */
 .dark-theme .mat-mdc-button:not(:disabled):hover .mdc-button__ripple::before,
-.dark-theme .mat-mdc-raised-button:not(:disabled):hover .mdc-button__ripple::before,
-.dark-theme .mat-mdc-outlined-button:not(:disabled):hover .mdc-button__ripple::before,
-.dark-theme .mat-mdc-unelevated-button:not(:disabled):hover .mdc-button__ripple::before {
+.dark-theme
+  .mat-mdc-raised-button:not(:disabled):hover
+  .mdc-button__ripple::before,
+.dark-theme
+  .mat-mdc-outlined-button:not(:disabled):hover
+  .mdc-button__ripple::before,
+.dark-theme
+  .mat-mdc-unelevated-button:not(:disabled):hover
+  .mdc-button__ripple::before {
   opacity: 0 !important;
 }
 
@@ -643,6 +649,35 @@ select:focus {
 .dark-theme .mat-mdc-icon-button:focus {
   outline: none !important;
   outline-offset: 0 !important;
+}
+
+/* Dark theme spinner colors */
+.dark-theme .mat-mdc-progress-spinner,
+.dark-theme .mat-spinner {
+  --mdc-circular-progress-active-indicator-color: var(--primary-color);
+}
+
+.dark-theme
+  .mat-mdc-progress-spinner
+  .mdc-circular-progress__determinate-circle,
+.dark-theme
+  .mat-mdc-progress-spinner
+  .mdc-circular-progress__indeterminate-circle-graphic,
+.dark-theme .mat-spinner .mdc-circular-progress__determinate-circle,
+.dark-theme .mat-spinner .mdc-circular-progress__indeterminate-circle-graphic {
+  stroke: var(--primary-color) !important;
+}
+
+/* Dark theme button spinner colors */
+.dark-theme .button-spinner {
+  --mdc-circular-progress-active-indicator-color: var(--button-text);
+}
+
+.dark-theme .button-spinner .mdc-circular-progress__determinate-circle,
+.dark-theme
+  .button-spinner
+  .mdc-circular-progress__indeterminate-circle-graphic {
+  stroke: var(--button-text) !important;
 }
 
 /* Chat and content backgrounds */

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -242,17 +242,21 @@ input[ng-reflect] {
   -webkit-font-smoothing: antialiased;
 }
 
-:root {
+/* Light Theme Variables */
+:root,
+.light-theme {
   --primary-color: #0077cc;
+  --primary-color-rgb: 0, 119, 204;
   --secondary-color: #005599;
   --background-color: #f8f9fa;
   --text-color: #001011;
+  --text-secondary: #666666;
   --border-color: #e0e0e0;
   --danger-color: #f44336;
   --success-color: #68b684;
   --warning-color: #ff9800;
-  --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.1);
-  --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.12);
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.04);
+  --shadow-md: 0 10px 40px rgba(0, 0, 0, 0.15);
   --border-radius: 8px;
   --header-height: 64px;
   --footer-height: 80px;
@@ -261,6 +265,65 @@ input[ng-reflect] {
   --spacing-md: 16px;
   --spacing-lg: 24px;
   --spacing-xl: 32px;
+
+  /* Component specific colors */
+  --card-background: #ffffff;
+  --input-background: #ffffff;
+  --input-border: #e0e0e0;
+  --button-background: var(--primary-color);
+  --button-text: #ffffff;
+  --header-background: rgba(255, 255, 255, 0.5);
+  --nav-hover: rgba(0, 119, 204, 0.08);
+  --warning-background: #fff3e0;
+  --warning-text: #e65100;
+  --info-background: #e1f5fe;
+  --info-text: #0277bd;
+  --chat-list-background: #ffffff;
+}
+
+/* Dark Theme Variables */
+.dark-theme {
+  --primary-color: #c3f73a;
+  --primary-color-rgb: 195, 247, 58;
+  --secondary-color: #95e06c;
+  --background-color: #0c2524;
+  --text-color: rgba(255, 255, 255, 0.9);
+  --text-secondary: rgba(255, 255, 255, 0.7);
+  --border-color: rgba(255, 255, 255, 0.1);
+  --danger-color: #ef5350;
+  --success-color: #68b684;
+  --warning-color: #ffb74d;
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.794);
+  --shadow-md: 0 10px 40px rgb(0, 0, 0);
+  --border-radius: 8px;
+  --header-height: 64px;
+  --footer-height: 80px;
+  --spacing-xs: 4px;
+  --spacing-sm: 8px;
+  --spacing-md: 16px;
+  --spacing-lg: 24px;
+  --spacing-xl: 32px;
+
+  /* Component specific colors */
+  /* --card-background: #102423; */
+  --card-background: #0c2524;
+  --input-background: rgba(255, 255, 255, 0);
+  --input-border: #3c4f4f;
+  --button-background: var(--primary-color);
+  --button-text: #001011;
+  --header-background: rgba(12, 37, 36, 0.5);
+  --nav-hover: rgba(195, 247, 58, 0.1);
+  --warning-background: rgba(255, 183, 77, 0.1);
+  --warning-text: #ffb74d;
+  --info-background: rgba(102, 187, 106, 0.1);
+  --info-text: #66bb6a;
+  --chat-list-background: #0c2524;
+}
+
+/* Dark theme background */
+.dark-theme body {
+  background: #011012;
+  background-attachment: fixed;
 }
 
 html,
@@ -467,4 +530,133 @@ body {
     animation: none;
     content: '⏳';
   }
+}
+
+/* Form input theming */
+input,
+textarea,
+select {
+  background-color: var(--input-background) !important;
+  border: 1px solid var(--input-border) !important;
+  color: var(--text-color) !important;
+  border-radius: var(--border-radius) !important;
+}
+
+input::placeholder,
+textarea::placeholder {
+  color: var(--text-secondary) !important;
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+  border-color: var(--primary-color) !important;
+  outline: none !important;
+}
+
+/* Dark theme specific focus override */
+.dark-theme input:focus,
+.dark-theme textarea:focus,
+.dark-theme select:focus {
+  border-color: var(--primary-color) !important;
+}
+
+/* Angular Material form field theming */
+.mat-mdc-form-field {
+  --mdc-filled-text-field-container-color: var(--input-background);
+  --mdc-filled-text-field-label-text-color: var(--text-secondary);
+  --mdc-filled-text-field-input-text-color: var(--text-color);
+  --mdc-filled-text-field-active-indicator-color: var(--primary-color);
+  --mdc-filled-text-field-focus-active-indicator-color: var(--primary-color);
+}
+
+/* Dark theme Angular Material form field overrides */
+.dark-theme .mat-mdc-form-field {
+  --mdc-filled-text-field-active-indicator-color: var(--primary-color);
+  --mdc-filled-text-field-focus-active-indicator-color: var(--primary-color);
+  --mdc-outlined-text-field-outline-color: var(--input-border);
+  --mdc-outlined-text-field-hover-outline-color: var(--input-border);
+  --mdc-outlined-text-field-focus-outline-color: var(--primary-color);
+  --mdc-outlined-text-field-label-text-color: var(--text-secondary);
+  --mdc-outlined-text-field-supporting-text-color: var(--text-secondary);
+  --mdc-shape-corner-size-medium: var(--border-radius);
+}
+
+/* Dark theme placeholder text color */
+.dark-theme input::placeholder,
+.dark-theme textarea::placeholder {
+  color: var(--text-secondary) !important;
+}
+
+/* Dark theme mat-label color */
+.dark-theme .mat-mdc-form-field .mat-mdc-floating-label {
+  color: var(--text-secondary) !important;
+}
+
+.mat-mdc-text-field-wrapper {
+  background-color: var(--input-background) !important;
+}
+
+.mat-mdc-form-field-input-control input {
+  color: var(--text-color) !important;
+  background-color: var(--input-background) !important;
+}
+
+/* Card backgrounds */
+.mat-mdc-card,
+.mat-card,
+.card {
+  background-color: var(--card-background) !important;
+  color: var(--text-color) !important;
+  border: 1px solid var(--border-color) !important;
+}
+
+/* Button theming */
+.mat-mdc-button,
+.mat-mdc-raised-button,
+.mat-mdc-unelevated-button {
+  --mdc-text-button-label-text-color: var(--text-color);
+  --mdc-filled-button-container-color: var(--button-background);
+  --mdc-filled-button-label-text-color: var(--button-text);
+}
+
+/* Override Material Design button hover effects for dark theme */
+.dark-theme .mat-mdc-button:not(:disabled):hover .mdc-button__ripple::before,
+.dark-theme .mat-mdc-raised-button:not(:disabled):hover .mdc-button__ripple::before,
+.dark-theme .mat-mdc-outlined-button:not(:disabled):hover .mdc-button__ripple::before,
+.dark-theme .mat-mdc-unelevated-button:not(:disabled):hover .mdc-button__ripple::before {
+  opacity: 0 !important;
+}
+
+.dark-theme .mat-mdc-button:not(:disabled):hover,
+.dark-theme .mat-mdc-raised-button:not(:disabled):hover,
+.dark-theme .mat-mdc-outlined-button:not(:disabled):hover,
+.dark-theme .mat-mdc-unelevated-button:not(:disabled):hover {
+  background-color: var(--nav-hover) !important;
+}
+
+/* Override Material Design focus outline */
+.dark-theme .mat-mdc-button:focus,
+.dark-theme .mat-mdc-raised-button:focus,
+.dark-theme .mat-mdc-outlined-button:focus,
+.dark-theme .mat-mdc-unelevated-button:focus {
+  outline: 2px solid var(--primary-color) !important;
+  outline-offset: 2px !important;
+}
+
+/* Chat and content backgrounds */
+.content-background {
+  background-color: var(--card-background) !important;
+  color: var(--text-color) !important;
+  border-color: var(--border-color) !important;
+}
+
+.chat-container {
+  color: var(--text-color) !important;
+  border-color: var(--border-color) !important;
+}
+
+.chat-info {
+  color: var(--text-color) !important;
+  border-color: var(--border-color) !important;
 }

--- a/landing/src/layouts/BaseLayout.astro
+++ b/landing/src/layouts/BaseLayout.astro
@@ -146,7 +146,10 @@ const finalStructuredData = structuredData || defaultStructuredData;
     <link rel='preload' href='/assets/images/logo.svg' as='image' />
 
     <!-- Cloudflare Web Analytics -->
-    <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "abbc680d9bdf4d34af843d4791b0f2a1"}'></script>
+    <script
+      defer
+      src='https://static.cloudflareinsights.com/beacon.min.js'
+      data-cf-beacon='{"token": "abbc680d9bdf4d34af843d4791b0f2a1"}'></script>
   </head>
 
   <body>


### PR DESCRIPTION
- Add theme service with local storage persistence
- Create CSS variables for light/dark theme colors
- Implement theme toggle in header component
- Add dark theme styles for all auth components
- Style chat components with proper dark theme support
- Fix Material Design button hover states in dark theme
- Add theme-aware cache info banner with green styling
- Remove performance-impacting background animations
- Add rounded corners and improved component layouts
- Fix chat-room layout with proper fixed positioning for desktop/mobile
- Remove unnecessary borders and dividers from headers
- Add larger padding for >1200px screens
- Fix unreadable message styling for both light/dark themes
- Improve cache-info-banner positioning and theming
- Remove Material Design focus outlines in dark theme
- Fix mobile chat-header background colors per theme
- Adjust scroll-to-bottom button positioning
- Remove padding/margins that caused layout issues
- Fix theme toggle to show target theme (sun/Light when dark, moon/Dark when light)
- Replace Material slide toggle with regular mat-button to prevent active state
- Increase mobile controls spacing and add margin to status element
- Fix hamburger menu button to use neutral text color by default
- Reorder navigation menu (Chats, Settings, Theme, Logout)
- Update logo to navigate to landing page instead of chat
- Set dark theme as default for new users
- Fix spinner colors for dark theme (green for app, dark for buttons)
- Update message backgrounds with better contrast
- Improve typing indicator positioning and styling
- Remove cache banner bottom borders in mobile
- Update unreadable message colors for both themes
- Add isMessageEncrypted method to detect encrypted messages from partner
- Style encrypted messages same as unreadable messages
- Add italic text and muted colors for encrypted message content
- Support both light and dark theme styling for encrypted messages
- Add 1px inner borders to all avatar images across the application
- Implement cross-browser compatible solution using outline for chat avatars
- Use dual pseudo-element borders for settings avatars to handle Safari/DuckDuckGo compatibility
- Support both light theme (#fff borders) and dark theme (#001011 borders)
- Resolve white layer visibility issues in SVG avatars against dark backgrounds
- Ensure perfect circular borders that mask jaggy edges on avatar images