### PR TITLE
fix: mobile chat window padding when cache-info-banner is visible

### DIFF
--- a/frontend/src/app/features/chat/chat-room/chat-room.component.css
+++ b/frontend/src/app/features/chat/chat-room/chat-room.component.css
@@ -702,12 +702,18 @@
   }
 
   .chat-window {
-    padding: var(--spacing-sm) var(--spacing-md);
     /* Calculate proper height: viewport - app header - chat header (60px) - chat form (80px) */
     height: calc(100vh - var(--header-height) - 60px - 80px);
+    padding: var(--spacing-xl) var(--spacing-md);
+    padding-top: calc(60px + var(--spacing-md)); /* Space for fixed chat header */
     overflow-y: auto;
     position: relative;
     padding-bottom: 100px;
+  }
+
+  /* When cache banner is visible, add extra top padding to account for its height */
+  .chat-container:has(.cache-info-banner) .chat-window {
+    padding-top: calc(60px + var(--spacing-md) + 60px); /* chat-header + spacing + banner space */
   }
 
   .chat-form {


### PR DESCRIPTION
- Add CSS :has() selector to detect cache-info-banner presence
- Automatically adjust chat-window top padding in mobile view
- Prevent messages from hiding under banner and chat-header