### PR TITLE
docs: add attribution for Boring Avatars design inspiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1045,6 +1045,8 @@ details.
 - Angular team for the amazing framework
 - Socket.IO for real-time capabilities
 - Web Crypto API for client-side encryption
+- [Boring Avatars](https://github.com/boringdesigners/boring-avatars) by Boring Designers for avatar
+  design inspiration (MIT License)
 - The open-source community
 
 ## 📞 Support

--- a/frontend/src/assets/images/avatars/README.md
+++ b/frontend/src/assets/images/avatars/README.md
@@ -1,0 +1,11 @@
+# Avatar Attribution
+
+These avatar designs are inspired by
+[Boring Avatars](https://github.com/boringdesigners/boring-avatars) by Boring Designers.
+
+Original work: MIT Licensed
+
+- Source: https://github.com/boringdesigners/boring-avatars
+- License: https://github.com/boringdesigners/boring-avatars/blob/main/LICENSE
+
+These specific avatar files were recreated in Figma based on the original design concepts.


### PR DESCRIPTION
- Add attribution in main README acknowledgments section
- Create dedicated README in avatars directory with proper licensing info
- Ensure MIT license compliance for avatar design inspiration