### PR TITLE
feat: strengthen environment variable validation and encryption security

### DIFF
--- a/backend/src/utils/encryption.utils.ts
+++ b/backend/src/utils/encryption.utils.ts
@@ -1,8 +1,9 @@
 import crypto from 'crypto';
+import env from '../config/env';
 
-// Use a key derived from environment variables for token encryption
+// Use a key derived from dedicated TOKEN_ENCRYPTION_SECRET for token encryption
 const ENCRYPTION_KEY = crypto.scryptSync(
-  process.env.TOKEN_ENCRYPTION_SECRET || process.env.JWT_SECRET || 'fallback-encryption-key',
+  env.TOKEN_ENCRYPTION_SECRET,
   'reset-token-salt',
   32,
 );


### PR DESCRIPTION
- Require TOKEN_ENCRYPTION_SECRET as mandatory environment variable
- Enforce minimum 32-character length for JWT_SECRET (256 bits)
- Ensure JWT_SECRET and TOKEN_ENCRYPTION_SECRET are different values
- Update encryption utils to use dedicated TOKEN_ENCRYPTION_SECRET
- Add clear error messages with generation instructions
- Prevent server startup with weak or missing security secrets